### PR TITLE
Fix eval issues, expand fast-path, improve response UX

### DIFF
--- a/backend/app/agent/consolidated_llm.py
+++ b/backend/app/agent/consolidated_llm.py
@@ -36,12 +36,15 @@ client = OpenAI(
 # Cache identical (query, context) pairs to avoid repeat LLM calls.
 # TTL-style: stores up to 128 recent queries in memory.
 _llm_cache: Dict[str, Dict[str, Any]] = {}
-_LLM_CACHE_MAX = 128
+_LLM_CACHE_MAX = 512
+
+
+_PROMPT_VERSION = "v3"  # Bump when prompt template changes to invalidate cache
 
 
 def _cache_key(user_query: str, conv_ctx: str) -> str:
-    """Deterministic cache key from query + conversation context."""
-    raw = f"{user_query.strip().lower()}|{conv_ctx.strip()}"
+    """Deterministic cache key from query + conversation context + prompt version."""
+    raw = f"{_PROMPT_VERSION}|{user_query.strip().lower()}|{conv_ctx.strip()}"
     return hashlib.md5(raw.encode()).hexdigest()
 
 # ── Prompts ────────────────────────────────────────────────────────────────────
@@ -103,12 +106,30 @@ Examples of off_topic (truly unrelated to AFL):
 
 ## SQL Generation Rules
 
+The ONLY tables in this database are: `matches`, `teams`, `players`, `player_stats`, `team_stats`, `live_games`, `betting_odds`, `squiggle_predictions`, `news_articles`. Do NOT reference any other tables.
+
 Database Schema:
 
 ### teams: id, name, abbreviation, stadium
 Use EXACT team names: Adelaide (NOT "Adelaide Crows"), Geelong (NOT "Geelong Cats"), Greater Western Sydney (NOT "GWS Giants"), Sydney (NOT "Sydney Swans"), West Coast (NOT "West Coast Eagles")
 
-### matches: id, season (INTEGER), round (VARCHAR), match_date (TIMESTAMP), home_team_id, away_team_id, home_score, away_score, venue, attendance
+Common venue aliases (use the DB canonical name in SQL):
+- MCG / Melbourne Cricket Ground → 'M.C.G.'
+- Marvel Stadium / Docklands / Etihad Stadium / Colonial Stadium / Telstra Dome → 'Marvel Stadium'
+- GMHBA Stadium / Kardinia Park / Simonds Stadium / Skilled Stadium → 'GMHBA Stadium'
+- The Gabba / Woolloongabba / Brisbane Cricket Ground → 'Gabba'
+- SCG / Sydney Cricket Ground → 'S.C.G.'
+- Optus Stadium / Perth Stadium → 'Optus Stadium'
+- Adelaide Oval → 'Adelaide Oval'
+- People First Stadium / Metricon Stadium / Carrara → 'People First Stadium'
+- Blundstone Arena / Bellerive Oval → 'Blundstone Arena'
+- UNSW Canberra Oval / Manuka Oval → 'UNSW Canberra Oval'
+- TIO Traeger Park / Traeger Park → 'TIO Traeger Park'
+When filtering by venue, use ILIKE for fuzzy matching: WHERE m.venue ILIKE '%MCG%' or WHERE m.venue ILIKE '%Marvel%'
+
+### matches: id, season (INTEGER), round (VARCHAR), match_date (TIMESTAMP), home_team_id, away_team_id, home_score, away_score, venue, attendance, home_q1_goals, home_q1_behinds, home_q2_goals, home_q2_behinds, home_q3_goals, home_q3_behinds, home_q4_goals, home_q4_behinds, away_q1_goals, away_q1_behinds, away_q2_goals, away_q2_behinds, away_q3_goals, away_q3_behinds, away_q4_goals, away_q4_behinds
+- Quarter scores are stored IN this table. Do NOT look for a separate `quarter_scores` table.
+- Quarter score formula: Q1 score = q1_goals * 6 + q1_behinds. Cumulative: Q2 total = q1 + q2, etc.
 - round values: regular rounds "0","1".."24"; finals: "Qualifying Final","Elimination Final","Semi Final","Preliminary Final","Grand Final"
 - ALWAYS include finals in round-by-round season queries
 - Contains historical data ({data_range})
@@ -126,7 +147,7 @@ Use EXACT team names: Adelaide (NOT "Adelaide Crows"), Geelong (NOT "Geelong Cat
 - "results so far" / "scores" → add WHERE lg.status IN ('completed', 'post_match')
 - Use same JOIN pattern as matches: JOIN teams t_home ON lg.home_team_id = t_home.id
 
-### players: id, name, team_id (CURRENT team only — WARNING: wrong for traded players), position, height, weight, debut_year
+### players: id, name, team_id (CURRENT team only — WARNING: wrong for traded players), height, weight, debut_year
 
 ### player_stats: match_id, player_id, team_id (team player played FOR — correct for trades!), disposals, kicks, handballs, marks, tackles, goals, behinds, hitouts, clearances, inside_50s, rebound_50s, contested_possessions, uncontested_possessions, contested_marks, marks_inside_50, one_percenters, bounces, goal_assist, clangers, free_kicks_for, free_kicks_against, fantasy_points, brownlow_votes, time_on_ground_pct
 - IMPORTANT: fantasy_points is PRE-COMPUTED in the database using official AFL Fantasy scoring. For fantasy queries, SELECT fantasy_points directly — do NOT ask the user which scoring system to use.
@@ -140,13 +161,42 @@ CRITICAL RULES:
 6. For temporal/trend queries: return ONE ROW PER SEASON, GROUP BY season
 7. For single-season performance: return ONE ROW PER MATCH (round-by-round)
 8. NEVER use CROSS JOIN
-9. CRITICAL: For "who won" or "who played" queries, SELECT must include:
+9. CRITICAL — PLAYER IDENTITY: Multiple players can share the same name (e.g. two different Josh Kennedys). ALWAYS GROUP BY p.id, p.name (not just p.name) when aggregating player stats, so same-name players are counted separately.
+10. CRITICAL: For "who won" or "who played" queries, SELECT must include:
    - Both team names (home_team, away_team)
    - Both scores (home_score, away_score)
    - Winner calculation (CASE statement)
    - Margin (ABS difference)
    - Match context (venue, match_date, round)
    Do NOT return only partial data like just margin or just one team!
+
+## CURRENT ROUND FALLBACK:
+For the CURRENT ROUND of the current season (where match data may not yet be in the `matches` table), use `live_games` with `status IN ('completed', 'post_match')` for scores, results, and game-level stats. For all prior rounds of the current season, use `matches` as normal — that data is ingested from AFL Tables weekly. The `player_stats` table only has rows for ingested matches, so current-round player stats may not be available yet.
+
+## DO NOT (common LLM mistakes):
+- DO NOT use round numbers like WHERE m.round = 1. Round is VARCHAR — use WHERE m.round = '1'
+- DO NOT join players.team_id for historical stats — it only stores CURRENT team. Use player_stats.team_id
+- DO NOT use CROSS JOIN or cartesian products
+- DO NOT generate INSERT/UPDATE/DELETE/DROP statements
+- DO NOT estimate goals by dividing scores by 6 — use actual goal columns
+- DO NOT use LIMIT without ORDER BY
+- DO NOT GROUP BY p.name alone for player stats — always include p.id to distinguish same-name players (e.g. Josh Kennedy played for both Sydney and West Coast)
+- DO NOT filter by player position (`p.position`) — this column is not populated. If asked for 'midfielders' or 'forwards', suggest filtering by relevant stats instead (high disposals for mids, high goals for forwards).
+- DO NOT reference tables that don't exist. Awards, draft picks, and ladder tables do NOT exist. Brownlow votes per game are in `player_stats.brownlow_votes`.
+
+## Few-shot SQL examples (error-prone patterns):
+
+Q: "How many goals did Hawkins kick in 2024?"
+SQL: SELECT p.name, SUM(ps.goals) AS total_goals FROM player_stats ps JOIN players p ON ps.player_id = p.id JOIN matches m ON ps.match_id = m.id WHERE p.name ILIKE '%Hawkins%' AND m.season = 2024 GROUP BY p.id, p.name
+
+Q: "Carlton's win-loss record in 2023"
+SQL: SELECT t.name, SUM(CASE WHEN (m.home_team_id = t.id AND m.home_score > m.away_score) OR (m.away_team_id = t.id AND m.away_score > m.home_score) THEN 1 ELSE 0 END) AS wins, SUM(CASE WHEN (m.home_team_id = t.id AND m.home_score < m.away_score) OR (m.away_team_id = t.id AND m.away_score < m.home_score) THEN 1 ELSE 0 END) AS losses, COUNT(*) AS games FROM matches m JOIN teams t ON (m.home_team_id = t.id OR m.away_team_id = t.id) WHERE t.name = 'Carlton' AND m.season = 2023 GROUP BY t.name
+
+Q: "Top 5 disposal getters in 2024"
+SQL: SELECT p.name, SUM(ps.disposals) AS total_disposals, t.name AS team FROM player_stats ps JOIN players p ON ps.player_id = p.id JOIN matches m ON ps.match_id = m.id JOIN teams t ON ps.team_id = t.id WHERE m.season = 2024 AND ps.disposals IS NOT NULL GROUP BY p.id, p.name, t.id, t.name ORDER BY total_disposals DESC NULLS LAST LIMIT 5
+
+Q: "Geelong's scoring trend from 2018 to 2024"
+SQL: SELECT m.season, ROUND(AVG(CASE WHEN m.home_team_id = t.id THEN m.home_score ELSE m.away_score END), 1) AS avg_score FROM matches m JOIN teams t ON (m.home_team_id = t.id OR m.away_team_id = t.id) WHERE t.name = 'Geelong' AND m.season BETWEEN 2018 AND 2024 GROUP BY m.season ORDER BY m.season
 
 Common patterns:
 - Team season record: JOIN teams t, filter (home_team_id=t.id OR away_team_id=t.id), CASE for wins/losses
@@ -225,7 +275,7 @@ Common patterns:
     "rounds": [...]
   }},
   "requires_visualization": true|false,
-  "chart_type": "line"|"bar"|"grouped_bar"|"scatter"|null,
+  "data_shape_hint": "temporal_trend"|"top_n_ranking"|"comparison"|"single_value"|"distribution"|null,
   "chart_config": {{
     "x_col_hint": "expected x-axis column name from the SQL (e.g. 'season', 'name')",
     "y_col_hint": "expected y-axis column name from the SQL (e.g. 'total_goals', 'avg_disposals')"
@@ -233,12 +283,17 @@ Common patterns:
   "sql": "SELECT ..."
 }}
 
-Chart type rules:
-- trend_analysis or temporal queries -> "line"
-- player_comparison -> "grouped_bar" (multiple metrics) or "bar"
-- top-N / ranking queries -> "bar"
-- simple_stat with single number -> null (no chart)
-- If unsure, set chart_type to null
+requires_visualization rules:
+- true: trends over time, comparisons of 3+ entities, top-N rankings (N≥3), round-by-round data
+- false: single facts/numbers, yes/no answers, match results, 1-2 row results, news/odds/tips
+
+Data shape hint rules (describes the SHAPE of the expected result, NOT the chart type):
+- temporal_trend: data has a time dimension (season, round) — one row per time period
+- top_n_ranking: data is a ranked list of items (players, teams) — ordered by a metric
+- comparison: side-by-side comparison of 2-5 entities across metrics
+- single_value: query returns a single number/fact — no chart needed
+- distribution: statistical spread of values (e.g., score distributions)
+- null: if unsure
 
 User question: {user_query}"""
 
@@ -383,7 +438,16 @@ class ConsolidatedQueryUnderstanding:
             entities = data.get("entities", {})
             requires_viz = bool(data.get("requires_visualization", False))
             sql = data.get("sql", "").strip()
-            chart_type = data.get("chart_type")  # May be null/None
+            # Map data_shape_hint to chart_type for downstream consumers
+            data_shape = data.get("data_shape_hint")
+            _SHAPE_TO_CHART = {
+                "temporal_trend": "line",
+                "top_n_ranking": "bar",
+                "comparison": "grouped_bar",
+                "single_value": None,
+                "distribution": "box",
+            }
+            chart_type = _SHAPE_TO_CHART.get(data_shape, data.get("chart_type"))
             chart_config = data.get("chart_config", {})
 
             # Intents that don't require SQL (handled by specialized tools)

--- a/backend/app/agent/fast_path.py
+++ b/backend/app/agent/fast_path.py
@@ -45,7 +45,9 @@ _AFL_KEYWORDS = re.compile(
     r"top\s?\d+|best|worst|most|least|highest|lowest|compare|comparison|"
     r"trend|over time|year by year|historical|performance|"
     r"bye|byes|home|away|attendance|venue|stadium|"
-    r"news|latest|current|happening|update|updates)\b",
+    r"news|latest|current|happening|update|updates|"
+    r"how\s+(?:has|did|is|are|was|were)|gone\s+(?:so\s+far|this)|this\s+year|"
+    r"form|career|season\s+so\s+far|averaging|kicked|played)\b",
     re.IGNORECASE
 )
 
@@ -69,6 +71,45 @@ def _get_off_topic_response():
         f"Try something like: \"How many goals did Hawkins kick in 2024?\" or "
         f"\"What are the odds for this week's games?\""
     )
+
+
+# ── Meta-question patterns ───────────────────────────────────────────────────
+_META_PATTERNS = re.compile(
+    r"^(what can you do|what do you do|help|how do I use|how does this work|"
+    r"what are you|who are you|what is this|capabilities|features|"
+    r"what questions can I ask|what kind of questions|what sort of questions|"
+    r"how to use this|give me examples|example questions|show me examples)\s*\??$",
+    re.IGNORECASE
+)
+
+
+def _get_meta_response() -> str:
+    """Response for meta-questions about the agent's capabilities."""
+    from app.data.database import get_data_recency
+    recency = get_data_recency()
+    earliest = recency["earliest_season"]
+    hist_season = recency["historical_latest_season"]
+    return (
+        f"I'm an AFL analytics assistant. I can answer questions about Australian Football League "
+        f"statistics from {earliest} to {hist_season}. Here's what I can help with:\n\n"
+        f"**Stats & Records**\n"
+        f"- \"How many goals did Tom Hawkins kick in 2024?\"\n"
+        f"- \"Top 5 disposal getters in 2023\"\n"
+        f"- \"Who won the 2024 grand final?\"\n\n"
+        f"**Comparisons & Trends**\n"
+        f"- \"Compare Cripps and Oliver in 2024\"\n"
+        f"- \"Show Carlton's scoring trend from 2018 to 2024\"\n\n"
+        f"**Live & Current**\n"
+        f"- \"What are the odds for this week?\"\n"
+        f"- \"Who should I tip this round?\"\n"
+        f"- \"What's the latest AFL news?\"\n\n"
+        f"Just ask a question in plain English!"
+    )
+
+
+def _is_meta_question(query: str) -> bool:
+    """Return True if the query is a meta-question about capabilities."""
+    return bool(_META_PATTERNS.match(query.strip()))
 
 
 def _is_off_topic(query: str) -> bool:
@@ -176,7 +217,7 @@ class FastPathRouter:
         JOIN matches m ON ps.match_id = m.id
         JOIN teams t ON ps.team_id = t.id
         WHERE m.season = {year} AND ps.goals IS NOT NULL
-        GROUP BY p.name, t.name
+        GROUP BY p.id, p.name, t.id, t.name
         ORDER BY total_goals DESC NULLS LAST
         LIMIT 5
     """
@@ -188,7 +229,7 @@ class FastPathRouter:
         JOIN matches m ON ps.match_id = m.id
         JOIN teams t ON ps.team_id = t.id
         WHERE m.season = {year} AND ps.disposals IS NOT NULL
-        GROUP BY p.name, t.name
+        GROUP BY p.id, p.name, t.id, t.name
         ORDER BY total_disposals DESC NULLS LAST
         LIMIT 5
     """
@@ -227,7 +268,7 @@ class FastPathRouter:
         JOIN matches m ON ps.match_id = m.id
         JOIN teams t ON ps.team_id = t.id
         WHERE m.season = {year}
-        GROUP BY p.name, t.name
+        GROUP BY p.id, p.name, t.id, t.name
         HAVING COUNT(*) >= 5
         ORDER BY avg_fantasy DESC NULLS LAST
         LIMIT 5
@@ -240,7 +281,7 @@ class FastPathRouter:
         JOIN matches m ON ps.match_id = m.id
         JOIN teams t ON ps.team_id = t.id
         WHERE m.season = {year} AND ps.brownlow_votes IS NOT NULL AND ps.brownlow_votes > 0
-        GROUP BY p.name, t.name
+        GROUP BY p.id, p.name, t.id, t.name
         ORDER BY total_votes DESC NULLS LAST
         LIMIT 1
     """
@@ -261,7 +302,7 @@ class FastPathRouter:
         JOIN matches m ON ps.match_id = m.id
         JOIN teams t ON ps.team_id = t.id
         WHERE LOWER(p.name) LIKE LOWER('%{player}%') AND m.season = {year}
-        GROUP BY p.name, t.name
+        GROUP BY p.id, p.name, t.id, t.name
     """
 
     _TEAM_LADDER_SQL = """
@@ -324,6 +365,69 @@ class FastPathRouter:
             SELECT m.away_team_id FROM matches m WHERE m.season = {year}
         )
         ORDER BY t.name
+    """
+
+    _ROUND_RESULTS_SQL = """
+        SELECT ht.name AS home_team, at.name AS away_team,
+               m.home_score, m.away_score,
+               CASE WHEN m.home_score > m.away_score THEN ht.name
+                    WHEN m.away_score > m.home_score THEN at.name
+                    ELSE 'Draw' END AS winner,
+               ABS(m.home_score - m.away_score) AS margin,
+               m.venue
+        FROM matches m
+        JOIN teams ht ON m.home_team_id = ht.id
+        JOIN teams at ON m.away_team_id = at.id
+        WHERE m.season = {year} AND m.round = '{round}'
+        ORDER BY m.match_date
+    """
+
+    _MATCH_RESULT_SQL = """
+        SELECT ht.name AS home_team, at.name AS away_team,
+               m.home_score, m.away_score,
+               CASE WHEN m.home_score > m.away_score THEN ht.name
+                    WHEN m.away_score > m.home_score THEN at.name
+                    ELSE 'Draw' END AS winner,
+               ABS(m.home_score - m.away_score) AS margin,
+               m.venue, m.round
+        FROM matches m
+        JOIN teams ht ON m.home_team_id = ht.id
+        JOIN teams at ON m.away_team_id = at.id
+        WHERE m.season = {year} AND m.round = '{round}'
+          AND ((ht.name = '{team1}' AND at.name = '{team2}')
+               OR (ht.name = '{team2}' AND at.name = '{team1}'))
+        LIMIT 1
+    """
+
+    _COLEMAN_SQL = """
+        SELECT p.name, SUM(ps.goals) AS total_goals, t.name AS team
+        FROM player_stats ps
+        JOIN players p ON ps.player_id = p.id
+        JOIN matches m ON ps.match_id = m.id
+        JOIN teams t ON ps.team_id = t.id
+        WHERE m.season = {year} AND ps.goals IS NOT NULL
+          AND m.round ~ '^[0-9]+$'
+        GROUP BY p.id, p.name, t.id, t.name
+        ORDER BY total_goals DESC NULLS LAST
+        LIMIT 1
+    """
+
+    _PLAYER_CAREER_SQL = """
+        SELECT p.name,
+               COUNT(DISTINCT m.id) AS games,
+               SUM(ps.goals) AS career_goals,
+               SUM(ps.disposals) AS career_disposals,
+               SUM(ps.marks) AS career_marks,
+               SUM(ps.tackles) AS career_tackles,
+               ROUND(AVG(ps.disposals), 1) AS avg_disposals,
+               ROUND(AVG(ps.goals), 1) AS avg_goals,
+               MIN(m.season) AS first_season,
+               MAX(m.season) AS last_season
+        FROM player_stats ps
+        JOIN players p ON ps.player_id = p.id
+        JOIN matches m ON ps.match_id = m.id
+        WHERE LOWER(p.name) LIKE LOWER('%{player}%')
+        GROUP BY p.id, p.name
     """
 
     _HIGHEST_SCORE_SQL = """
@@ -501,6 +605,69 @@ class FastPathRouter:
                 lines.append(f"Round {rd}: {winner} def. {loser} by {margin} pts ({hs}-{aws})")
         header = f"{team1} vs {team2} in {year}:"
         return header + "\n" + "\n".join(lines)
+
+    @staticmethod
+    def _fmt_round_results(df, year: int, round: str = "", **_) -> str:
+        if df is None or len(df) == 0:
+            return None
+        lines = [f"Round {round}, {year} results:\n"]
+        for _, row in df.iterrows():
+            home = row["home_team"]
+            away = row["away_team"]
+            hs, aws = int(row["home_score"]), int(row["away_score"])
+            winner = row["winner"]
+            margin = int(row["margin"])
+            if winner == "Draw":
+                lines.append(f"- {home} {hs} drew with {away} {aws}")
+            else:
+                loser = away if winner == home else home
+                lines.append(f"- {winner} def. {loser} by {margin} pts ({hs}-{aws})")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _fmt_match_result(df, year: int, team1: str = "", team2: str = "", round: str = "", **_) -> str:
+        if df is None or len(df) == 0:
+            return None
+        row = df.iloc[0]
+        home = row["home_team"]
+        away = row["away_team"]
+        hs, aws = int(row["home_score"]), int(row["away_score"])
+        winner = row["winner"]
+        margin = int(row["margin"])
+        venue = row.get("venue", "")
+        venue_text = f" at {venue}" if venue else ""
+        if winner == "Draw":
+            return f"Round {round} {year}: {home} {hs} drew with {away} {aws}{venue_text}."
+        loser = away if winner == home else home
+        return f"{winner} defeated {loser} by {margin} points ({hs}-{aws}) in Round {round} {year}{venue_text}."
+
+    @staticmethod
+    def _fmt_coleman(df, year: int, **_) -> str:
+        if df is None or len(df) == 0:
+            return None
+        row = df.iloc[0]
+        return (f"{row['name']} ({row['team']}) was the leading goal kicker in {year} "
+                f"with {int(row['total_goals'])} goals (home-and-away season).")
+
+    @staticmethod
+    def _fmt_player_career(df, player: str = "", **_) -> str:
+        if df is None or len(df) == 0:
+            return None
+        if len(df) > 1:
+            return None  # Ambiguous — fall through
+        row = df.iloc[0]
+        name = row["name"]
+        games = int(row["games"])
+        goals = int(row["career_goals"]) if row["career_goals"] else 0
+        disposals = int(row["career_disposals"]) if row["career_disposals"] else 0
+        marks = int(row["career_marks"]) if row["career_marks"] else 0
+        tackles = int(row["career_tackles"]) if row["career_tackles"] else 0
+        first = int(row["first_season"])
+        last = int(row["last_season"])
+        return (
+            f"{name}'s career stats ({first}–{last}): {games} games, "
+            f"{goals} goals, {disposals} disposals, {marks} marks, {tackles} tackles."
+        )
 
     @staticmethod
     def _fmt_highest_score(df, year: int, **_) -> str:
@@ -701,6 +868,78 @@ class FastPathRouter:
                 requires_team=False,
                 requires_season=True,
             ),
+
+            # Head-to-head — "Carlton vs Essendon 2024" / "Geelong vs Sydney record in 2023"
+            QueryPattern(
+                name="head_to_head",
+                regex=re.compile(
+                    r"(.+?)\s+(?:vs?\.?|versus)\s+(.+?)\s+(?:in\s+)?(\d{4})"
+                    r"|(.+?)\s+(?:vs?\.?|versus)\s+(.+?)\s+(?:record|results?|history)\s*(?:in\s+)?(\d{4})",
+                    re.IGNORECASE
+                ),
+                sql_template=cls._HEAD_TO_HEAD_SQL,
+                response_formatter=cls._fmt_head_to_head,
+                requires_team=False,  # handled specially
+                requires_season=True,
+            ),
+
+            # Round results — "what happened in round 5 2024" / "round 3 results 2024"
+            QueryPattern(
+                name="round_results",
+                regex=re.compile(
+                    r"(?:what\s+happened\s+in\s+|results?\s+(?:for|from|of)\s+)?"
+                    r"(?:round|r)\s*(\d{1,2})\s+(?:in\s+)?(\d{4})"
+                    r"|(\d{4})\s+(?:round|r)\s*(\d{1,2})\s*(?:results?)?",
+                    re.IGNORECASE
+                ),
+                sql_template=cls._ROUND_RESULTS_SQL,
+                response_formatter=cls._fmt_round_results,
+                requires_team=False,
+                requires_season=True,
+            ),
+
+            # Match result — "score in round 5 Collingwood vs Carlton 2024"
+            QueryPattern(
+                name="match_result",
+                regex=re.compile(
+                    r"(?:score|result)\s+(?:in\s+)?(?:round|r)\s*(\d{1,2})"
+                    r"\s+(.+?)\s+(?:vs?\.?|versus)\s+(.+?)\s+(?:in\s+)?(\d{4})",
+                    re.IGNORECASE
+                ),
+                sql_template=cls._MATCH_RESULT_SQL,
+                response_formatter=cls._fmt_match_result,
+                requires_team=False,
+                requires_season=True,
+            ),
+
+            # Coleman Medal — "who won the Coleman in 2024" / "Coleman medal winner 2024"
+            QueryPattern(
+                name="coleman_winner",
+                regex=re.compile(
+                    r"(?:who\s+won|winner\s+of(?:\s+the)?)\s+(?:the\s+)?coleman"
+                    r"(?:\s+medal)?(?:\s+in)?\s*(\d{4})"
+                    r"|(\d{4})\s*coleman(?:\s+medal)?\s*(?:winner|medallist)?",
+                    re.IGNORECASE
+                ),
+                sql_template=cls._COLEMAN_SQL,
+                response_formatter=cls._fmt_coleman,
+                requires_team=False,
+                requires_season=True,
+            ),
+
+            # Player career stats — "Dustin Martin career goals" / "how many career goals has Martin kicked"
+            QueryPattern(
+                name="player_career_stats",
+                regex=re.compile(
+                    r"(?:(.+?)(?:'s)?\s+career\s+(?:stats?|statistics|goals?|disposals?|marks?|tackles?|games?))"
+                    r"|(?:how\s+many\s+career\s+(?:goals?|disposals?|games?)\s+(?:has|did)\s+(.+?)\s+(?:kick|have|play))",
+                    re.IGNORECASE
+                ),
+                sql_template=cls._PLAYER_CAREER_SQL,
+                response_formatter=cls._fmt_player_career,
+                requires_team=False,
+                requires_season=False,
+            ),
         ]
 
     @classmethod
@@ -795,6 +1034,41 @@ class FastPathRouter:
         from app.agent.tools import DatabaseTool
         from app.utils.cache import get_cached_result, set_cached_result
 
+        # Meta-question detection — "what can you do?", "help", etc.
+        if _is_meta_question(user_query):
+            logger.info(f"FAST-PATH: Meta-question detected: {user_query[:80]}")
+            return {
+                "user_query": user_query,
+                "intent": QueryIntent.SIMPLE_STAT,
+                "entities": {},
+                "needs_clarification": False,
+                "clarification_question": None,
+                "analysis_plan": ["Meta-question"],
+                "requires_visualization": False,
+                "chart_type": None,
+                "fallback_approach": None,
+                "analysis_mode": "summary",
+                "analysis_types": [],
+                "context_insights": {},
+                "data_quality": {},
+                "stats_summary": {},
+                "sql_query": None,
+                "sql_validated": False,
+                "query_results": None,
+                "statistical_analysis": {},
+                "execution_error": None,
+                "visualization_spec": None,
+                "natural_language_summary": _get_meta_response(),
+                "confidence": 1.0,
+                "sources": [],
+                "current_step": WorkflowStep.RESPOND,
+                "thinking_message": "Done",
+                "errors": [],
+                "socketio_emit": socketio_emit,
+                "conversation_history": conversation_history or [],
+                "conversation_id": None,
+            }
+
         # Off-topic detection — reject clearly non-AFL queries immediately
         # BUT: If there's conversation history, the query might be a follow-up
         # that doesn't contain AFL keywords (e.g., "Who came second?" after asking about Grand Final)
@@ -858,14 +1132,42 @@ class FastPathRouter:
 
             # Extract year from whichever capture group matched
             year_str = next((g for g in match.groups() if g and g.isdigit() and len(g) == 4), None)
-            if not year_str:
+            if not year_str and pattern.requires_season:
                 logger.debug(f"FAST-PATH: No year found in match groups {match.groups()}")
                 continue
 
-            year = cls._validate_year(year_str)
-            if year is None:
+            year = cls._validate_year(year_str) if year_str else None
+            if year is None and pattern.requires_season:
                 logger.debug(f"FAST-PATH: Year {year_str} out of valid range")
                 continue
+
+            # Guard: detect when the query is more specific than the pattern can handle
+            query_lower = user_query.lower()
+
+            # Skip season-aggregate patterns when query references a specific round/match
+            _SEASON_AGGREGATE_PATTERNS = {
+                "top_goal_kickers", "top_disposal_getters", "afl_fantasy_top_scorers",
+                "brownlow_winner", "coleman_winner", "team_season_record", "team_ladder_position",
+            }
+            if pattern.name in _SEASON_AGGREGATE_PATTERNS:
+                has_round_ref = bool(re.search(r'\bround\s+\d{1,2}\b', query_lower))
+                has_match_ref = any(kw in query_lower for kw in ['match between', 'game between', 'match against'])
+                if has_round_ref or has_match_ref:
+                    logger.info(f"FAST-PATH: Skipping season-aggregate pattern '{pattern.name}' — query references specific round/match")
+                    continue
+
+            # Skip match-level patterns (round_results, match_result, head_to_head) when
+            # query asks for player-level stats — these patterns only return team scores
+            _MATCH_LEVEL_PATTERNS = {"round_results", "match_result", "head_to_head"}
+            _PLAYER_STAT_KEYWORDS = [
+                "fantasy", "disposal", "kick", "handball", "mark", "tackle",
+                "hitout", "clearance", "goal kicker", "player", "stats", "scoring",
+                "contested", "inside 50", "brownlow", "best on ground",
+            ]
+            if pattern.name in _MATCH_LEVEL_PATTERNS:
+                if any(kw in query_lower for kw in _PLAYER_STAT_KEYWORDS):
+                    logger.info(f"FAST-PATH: Skipping match-level pattern '{pattern.name}' — query asks for player stats")
+                    continue
 
             # Extract team if required
             team = None
@@ -875,19 +1177,52 @@ class FastPathRouter:
                     logger.debug(f"FAST-PATH: Pattern '{pattern.name}' requires team but none found")
                     continue  # Try next pattern
 
-            # Extract round number for round_byes pattern
+            # Extract round number for round-related patterns
             round_num = None
             if pattern.name == "round_byes":
-                # Group 1 is round number, group 2 is year
                 round_num = match.group(1)
                 if not round_num:
                     logger.debug(f"FAST-PATH: round_byes requires round but none found")
                     continue
+            elif pattern.name == "round_results":
+                # Groups: (round, year) or (year, round) depending on which alt matched
+                groups = match.groups()
+                round_num = groups[0] or groups[3]
+                year_str = groups[1] or groups[2]
+                if not round_num:
+                    continue
+                year = cls._validate_year(year_str)
+                if year is None:
+                    continue
+            elif pattern.name == "match_result":
+                # Groups: round, team1_text, team2_text, year
+                round_num = match.group(1)
 
-            # Extract player if needed (for player_season_stats pattern)
+            # Extract two teams for head-to-head and match_result patterns
+            team1, team2 = None, None
+            if pattern.name == "head_to_head":
+                groups = match.groups()
+                t1_text = groups[0] or groups[3]
+                t2_text = groups[1] or groups[4]
+                if t1_text and t2_text:
+                    team1 = cls._extract_team(t1_text.strip())
+                    team2 = cls._extract_team(t2_text.strip())
+                if not team1 or not team2:
+                    logger.debug(f"FAST-PATH: head_to_head requires two teams but couldn't resolve both")
+                    continue
+            elif pattern.name == "match_result":
+                t1_text = match.group(2)
+                t2_text = match.group(3)
+                if t1_text and t2_text:
+                    team1 = cls._extract_team(t1_text.strip())
+                    team2 = cls._extract_team(t2_text.strip())
+                if not team1 or not team2:
+                    logger.debug(f"FAST-PATH: match_result requires two teams but couldn't resolve both")
+                    continue
+
+            # Extract player if needed (for player_season_stats and player_career_stats patterns)
             player = None
             if pattern.name == "player_season_stats":
-                # Try to get player name from regex capture groups (groups 1-3 are player name)
                 player = next((g for g in match.groups()[:3] if g and not g.isdigit()), None)
                 if player:
                     player = player.strip()
@@ -895,6 +1230,15 @@ class FastPathRouter:
                     player = cls._extract_player_name(user_query)
                 if not player:
                     logger.debug(f"FAST-PATH: player_season_stats requires player but none found")
+                    continue
+            elif pattern.name == "player_career_stats":
+                player = next((g for g in match.groups() if g and not g.isdigit()), None)
+                if player:
+                    player = player.strip()
+                else:
+                    player = cls._extract_player_name(user_query)
+                if not player:
+                    logger.debug(f"FAST-PATH: player_career_stats requires player but none found")
                     continue
 
             # Emit progress to WebSocket
@@ -908,7 +1252,8 @@ class FastPathRouter:
             try:
                 sql = pattern.sql_template.format(
                     year=year, team=team or "", player=player or "",
-                    round=round_num or ""
+                    round=round_num or "",
+                    team1=team1 or "", team2=team2 or "",
                 )
                 sql = " ".join(sql.split())  # Normalise whitespace
 
@@ -935,7 +1280,8 @@ class FastPathRouter:
                         return None
 
                 # Format response
-                fmt_kwargs = {"year": year, "team": team, "player": player, "round": round_num}
+                fmt_kwargs = {"year": year, "team": team, "player": player, "round": round_num,
+                              "team1": team1, "team2": team2}
                 response_text = pattern.response_formatter(df, **fmt_kwargs)
 
                 if response_text is None:
@@ -946,11 +1292,11 @@ class FastPathRouter:
 
                 # Build AgentState-compatible result
                 entities: Dict[str, Any] = {
-                    "teams": [team] if team else [],
-                    "players": [],
-                    "seasons": [str(year)],
+                    "teams": ([team1, team2] if team1 and team2 else [team] if team else []),
+                    "players": [player] if player else [],
+                    "seasons": [str(year)] if year else [],
                     "metrics": [],
-                    "rounds": [],
+                    "rounds": [str(round_num)] if round_num else [],
                 }
 
                 return {

--- a/backend/app/agent/graph.py
+++ b/backend/app/agent/graph.py
@@ -481,6 +481,14 @@ class AFLAnalyticsAgent:
 
             state["requires_visualization"] = understanding.get("requires_visualization", False)
 
+            # Force visualization if user explicitly requested a chart type
+            from app.visualization.chart_selector import ChartSelector
+            explicit_chart = ChartSelector._detect_explicit_chart_type(state["user_query"])
+            if explicit_chart:
+                state["requires_visualization"] = True
+                state["llm_chart_type_hint"] = explicit_chart
+                logger.info(f"UNDERSTAND: User explicitly requested '{explicit_chart}' chart — forcing visualization")
+
             logger.info(f"Intent: {state['intent']}, Raw entities: {raw_entities}, Resolved entities: {state['entities']}")
 
         except Exception as e:
@@ -790,12 +798,40 @@ class AFLAnalyticsAgent:
                 logger.info(f"EXECUTE: Database query result: success={db_result.get('success')}, rows={db_result.get('rows_returned')}, error={db_result.get('error')}")
 
                 if not db_result["success"]:
-                    error_msg = f"Database query failed: {db_result['error']}"
-                    logger.error(f"{error_msg} | SQL: {state.get('sql_query', 'N/A')}")
-                    state["execution_error"] = error_msg
-                    state["errors"].append(error_msg)
-                    state["thinking_message"] = "Couldn't retrieve data, retrying..."
-                    return state
+                    # --- LLM SQL retry (max 1 attempt) ---
+                    raw_error = db_result.get("raw_error", db_result["error"])
+                    logger.warning(f"EXECUTE: SQL failed, attempting LLM retry. Error: {raw_error}")
+                    state["thinking_message"] = "Query failed, retrying with fix..."
+                    self._emit_progress(state, "execute", "Query failed, retrying with fix...")
+
+                    retried_sql = self._llm_retry_sql(
+                        original_sql=state["sql_query"],
+                        error_message=raw_error,
+                        user_query=state["user_query"],
+                    )
+                    if retried_sql and retried_sql != state["sql_query"]:
+                        logger.info(f"EXECUTE: Retrying with LLM-corrected SQL: {retried_sql[:200]}...")
+                        db_result2 = DatabaseTool.query_database(retried_sql)
+                        if db_result2["success"]:
+                            logger.info(f"EXECUTE: LLM retry succeeded with {db_result2['rows_returned']} rows")
+                            state["sql_query"] = retried_sql
+                            state["sql_validated"] = True
+                            state["query_results"] = db_result2["data"]
+                            set_cached_result(retried_sql, db_result2["data"])
+                            # Skip the error path — jump to stats
+                            db_result = db_result2
+                        else:
+                            logger.error(f"EXECUTE: LLM retry also failed: {db_result2.get('error')}")
+                            error_msg = f"Database query failed: {db_result['error']}"
+                            state["execution_error"] = error_msg
+                            state["errors"].append(error_msg)
+                            return state
+                    else:
+                        error_msg = f"Database query failed: {db_result['error']}"
+                        logger.error(f"{error_msg} | SQL: {state.get('sql_query', 'N/A')}")
+                        state["execution_error"] = error_msg
+                        state["errors"].append(error_msg)
+                        return state
 
                 state["sql_validated"] = True
                 state["query_results"] = db_result["data"]
@@ -921,8 +957,18 @@ class AFLAnalyticsAgent:
             if len(data) < MIN_DATA_POINTS:
                 logger.warning(f"Insufficient data for visualization: {len(data)} rows (need at least {MIN_DATA_POINTS})")
                 state["thinking_message"] = f"⚠️ Not enough data points for chart ({len(data)} rows)"
-                # Skip visualization - will go to respond node without chart
                 return state
+
+            # VALIDATION: Skip chart if every row has the same x-axis value (e.g., all "Charlie Cameron")
+            # — a bar chart with duplicate x labels is meaningless; the table is better
+            non_numeric = data.select_dtypes(exclude=['number']).columns.tolist()
+            temporal_cols_present = [c for c in data.columns if c in ['season', 'year', 'match_date', 'round']]
+            if non_numeric and not temporal_cols_present:
+                likely_x = non_numeric[0]
+                if data[likely_x].nunique() == 1 and len(data) <= 10:
+                    logger.info(f"VISUALIZE: Skipping chart — x-axis '{likely_x}' has only 1 unique value across {len(data)} rows")
+                    state["thinking_message"] = "Table is more useful than a chart for this data"
+                    return state
 
             # Use intelligent ChartSelector to determine optimal chart configuration
             user_query = state.get("user_query", "")
@@ -974,6 +1020,18 @@ class AFLAnalyticsAgent:
                     params["y_col"] = y_col
                 if group_col:
                     params["group_col"] = group_col
+
+            # ── POST-VALIDATION: sanity-check chart_type vs data shape ────────
+            # Skip type-changing overrides if user explicitly requested a chart type
+            user_explicit = chart_config.get("user_explicit", False)
+            if not user_explicit:
+                chart_type, x_col, y_col = self._validate_chart_selection(
+                    chart_type, x_col, y_col, data, user_query
+                )
+            # Update params after validation may have changed x/y_col
+            if isinstance(y_col, str):
+                params["x_col"] = x_col
+                params["y_col"] = y_col
 
             # AUTO-AGGREGATE: If charting by season but data has multiple rows per season
             # (e.g., per-game stats for a career trend), aggregate to season averages.
@@ -1077,6 +1135,239 @@ class AFLAnalyticsAgent:
             state["thinking_message"] = "Skipping chart generation"
 
         return state
+
+    @staticmethod
+    def _validate_chart_selection(
+        chart_type: str,
+        x_col: Optional[str],
+        y_col: Any,
+        data: Any,
+        user_query: str,
+    ) -> tuple:
+        """Post-validate chart type vs actual data shape. Returns (chart_type, x_col, y_col)."""
+        import pandas as pd
+
+        if not isinstance(data, pd.DataFrame) or len(data) == 0:
+            return chart_type, x_col, y_col
+
+        n_rows = len(data)
+
+        # Rule: Line charts need at least 3 data points to show a trend
+        if chart_type == "line" and n_rows < 3:
+            logger.info(f"CHART-VALIDATE: line→bar (only {n_rows} rows, need ≥3 for trend)")
+            chart_type = "bar"
+
+        # Rule: Vertical bar charts — cap at 12 categories for readability
+        if chart_type == "bar" and n_rows > 12:
+            logger.info(f"CHART-VALIDATE: bar→horizontal_bar ({n_rows} categories exceeds 12)")
+            chart_type = "horizontal_bar"
+
+        # Rule: Pie charts — only valid for 2-7 categories
+        if chart_type == "pie":
+            if n_rows > 7:
+                logger.info(f"CHART-VALIDATE: pie→bar ({n_rows} categories too many for pie)")
+                chart_type = "bar"
+            elif n_rows < 2:
+                logger.info(f"CHART-VALIDATE: pie→bar (only {n_rows} category)")
+                chart_type = "bar"
+
+        # Rule: Scatter needs at least 5 points to be useful
+        if chart_type == "scatter" and n_rows < 5:
+            logger.info(f"CHART-VALIDATE: scatter→bar (only {n_rows} points)")
+            chart_type = "bar"
+
+        # Rule: Validate x_col and y_col actually exist in data
+        if x_col and x_col not in data.columns:
+            fallback_x = data.columns[0]
+            logger.info(f"CHART-VALIDATE: x_col '{x_col}' not in data, using '{fallback_x}'")
+            x_col = fallback_x
+
+        if isinstance(y_col, str) and y_col not in data.columns:
+            numeric_cols = data.select_dtypes(include=["number"]).columns.tolist()
+            numeric_cols = [c for c in numeric_cols if "id" not in c.lower()]
+            if numeric_cols:
+                fallback_y = numeric_cols[0]
+                logger.info(f"CHART-VALIDATE: y_col '{y_col}' not in data, using '{fallback_y}'")
+                y_col = fallback_y
+
+        return chart_type, x_col, y_col
+
+    @staticmethod
+    def _get_example_queries(intent: Optional[str] = None, entities: Optional[Dict] = None) -> str:
+        """Return 2-3 example queries relevant to the user's intent."""
+        examples_by_intent = {
+            "simple_stat": [
+                "How many goals did Hawkins kick in 2024?",
+                "Who won the 2024 grand final?",
+                "What was Carlton's record in 2023?",
+            ],
+            "player_comparison": [
+                "Compare Cripps and Oliver in 2024",
+                "Top 5 disposal getters in 2024",
+            ],
+            "team_analysis": [
+                "How did Collingwood perform in 2023?",
+                "Show Carlton's scoring trend from 2018 to 2024",
+            ],
+            "trend_analysis": [
+                "Show Geelong's win count per season from 2018 to 2024",
+                "Cripps disposal average over time",
+            ],
+        }
+        intent_key = str(intent).lower().replace("queryintent.", "") if intent else ""
+        examples = examples_by_intent.get(intent_key, examples_by_intent["simple_stat"])
+        formatted = "\n".join(f'- "{e}"' for e in examples[:2])
+        return f"\n\nHere are some example queries:\n{formatted}"
+
+    @staticmethod
+    def _build_error_response(state: Dict[str, Any]) -> str:
+        """Build a helpful error response based on context."""
+        intent = state.get("intent")
+        entities = state.get("entities", {})
+        error_detail = state.get("execution_error", "")
+        players = entities.get("players", [])
+        teams = entities.get("teams", [])
+
+        from app.data.database import get_data_recency
+        recency = get_data_recency()
+        earliest = recency["earliest_season"]
+        hist_season = recency["historical_latest_season"]
+
+        # Tailor the message to the error type
+        if "connection" in error_detail.lower() or "timeout" in error_detail.lower():
+            return (
+                "I'm having trouble reaching the database right now. "
+                "Please try again in a moment."
+            )
+
+        parts = ["I wasn't able to answer that query."]
+
+        if players:
+            parts.append(
+                f"Check that \"{players[0]}\" is spelled correctly — "
+                f"I match player names from AFL Tables data ({earliest}–{hist_season})."
+            )
+        elif teams:
+            parts.append(
+                f"I have data for all 18 AFL teams from {earliest} to {hist_season}. "
+                f"Make sure the team name is correct."
+            )
+        else:
+            parts.append(
+                f"I have AFL data from {earliest} to {hist_season}. "
+                f"Try being more specific about the team, player, or season."
+            )
+
+        examples = AFLAnalyticsAgent._get_example_queries(intent, entities)
+        parts.append(examples)
+
+        parts.append(
+            "\nIf you think this data should be available, "
+            "raise a request using the report button and I'll look into it."
+        )
+
+        return " ".join(parts[:2]) + "".join(parts[2:])
+
+    @staticmethod
+    def _build_empty_results_response(state: Dict[str, Any]) -> str:
+        """Build a helpful response when the query returned no results."""
+        entities = state.get("entities", {})
+        intent = state.get("intent")
+        players = entities.get("players", [])
+        teams = entities.get("teams", [])
+        seasons = entities.get("seasons", [])
+
+        from app.data.database import get_data_recency
+        recency = get_data_recency()
+        earliest = recency["earliest_season"]
+        hist_season = recency["historical_latest_season"]
+        hist_round = recency["historical_latest_round"]
+
+        parts = ["I couldn't find any data matching your query."]
+
+        if players and seasons:
+            parts.append(
+                f"I don't have stats for {players[0]} in {seasons[0]}. "
+                f"Player data covers {earliest} through Round {hist_round} of {hist_season}. "
+                f"The player may not have played that season, or the name could be misspelled."
+            )
+        elif players:
+            parts.append(
+                f"Check that \"{players[0]}\" is spelled correctly. "
+                f"I have player stats from {earliest} to {hist_season}."
+            )
+        elif teams and seasons:
+            parts.append(
+                f"No results for {teams[0]} in {seasons[0]}. "
+                f"Match data covers {earliest} to {hist_season}."
+            )
+        else:
+            # Check if user asked about remaining/upcoming games
+            query_lower = state.get("user_query", "").lower()
+            remaining_keywords = ["left", "remaining", "upcoming", "scheduled", "still to play"]
+            if any(kw in query_lower for kw in remaining_keywords):
+                parts = ["All games this round have been completed — no remaining games to play."]
+            else:
+                parts.append(
+                    f"I have AFL data from {earliest} to {hist_season}. "
+                    f"Try checking the team/player name or adjusting the season."
+                )
+
+        examples = AFLAnalyticsAgent._get_example_queries(intent, entities)
+        parts.append(examples)
+
+        parts.append(
+            "\nIf you think this data should be available, "
+            "raise a request using the report button and I'll look into it."
+        )
+
+        return " ".join(parts[:2]) + "".join(parts[2:])
+
+    @staticmethod
+    def _llm_retry_sql(original_sql: str, error_message: str, user_query: str) -> Optional[str]:
+        """
+        Ask the LLM to fix a failed SQL query based on the Postgres error.
+
+        Returns corrected SQL string, or None if unable to fix.
+        """
+        try:
+            prompt = f"""Fix this PostgreSQL query that failed with an error.
+
+Original SQL:
+{original_sql}
+
+Postgres error:
+{error_message}
+
+User's question: {user_query}
+
+Return ONLY the corrected SQL query, nothing else. No markdown, no explanation.
+If you cannot fix it, return the string UNFIXABLE."""
+
+            response = client.chat.completions.create(
+                model=os.getenv("OPENAI_MODEL_FAST", "gpt-5-mini"),
+                messages=[{"role": "user", "content": prompt}],
+            )
+            fixed = (response.choices[0].message.content or "").strip()
+
+            # Clean up response
+            if "```sql" in fixed:
+                fixed = fixed.split("```sql")[1].split("```")[0].strip()
+            elif "```" in fixed:
+                fixed = fixed.split("```")[1].split("```")[0].strip()
+
+            if fixed.upper().startswith("UNFIXABLE") or not fixed.upper().startswith(("SELECT", "WITH")):
+                logger.info("LLM SQL retry: could not fix the query")
+                return None
+
+            # Normalize whitespace
+            fixed = " ".join(fixed.split())
+            logger.info(f"LLM SQL retry: generated fix ({len(fixed)} chars)")
+            return fixed
+
+        except Exception as e:
+            logger.error(f"LLM SQL retry failed: {e}")
+            return None
 
     def _format_stats_for_gpt(self, stats: Dict[str, Any]) -> str:
         """
@@ -1192,6 +1483,56 @@ class AFLAnalyticsAgent:
         return "\n".join(parts)
 
     @staticmethod
+    def _humanize_value_label(col_name: str) -> str:
+        """Convert database column names to natural response labels."""
+        _LABEL_MAP = {
+            "total_goals": "goals",
+            "total_disposals": "disposals",
+            "total_marks": "marks",
+            "total_tackles": "tackles",
+            "total_kicks": "kicks",
+            "total_handballs": "handballs",
+            "total_votes": "votes",
+            "total_fantasy": "fantasy points",
+            "total_score": "points",
+            "win_count": "wins",
+            "loss_count": "losses",
+            "draw_count": "draws",
+            "top4_count": "top-four finishes",
+            "games_played": "games",
+            "avg_disposals": "average disposals per game",
+            "avg_goals": "average goals per game",
+            "avg_score": "average score",
+            "avg_margin": "average margin",
+            "avg_fantasy": "average fantasy points per game",
+            "career_goals": "career goals",
+            "career_disposals": "career disposals",
+            "win_rate": "win rate",
+            "win_percentage": "win percentage",
+            "home_wins": "home wins",
+            "away_wins": "away wins",
+            "attendance": "attendance",
+        }
+        lower = col_name.lower()
+        if lower in _LABEL_MAP:
+            return _LABEL_MAP[lower]
+        # Strip common prefixes
+        for prefix in ("total_", "avg_", "count_", "sum_", "num_"):
+            if lower.startswith(prefix):
+                return lower[len(prefix):].replace("_", " ")
+        return lower.replace("_", " ")
+
+    @staticmethod
+    def _strip_id_columns(data):
+        """Remove id and *_id columns from DataFrame to prevent leaking DB IDs in responses."""
+        import pandas as pd
+        if isinstance(data, pd.DataFrame) and len(data) > 0:
+            id_cols = [c for c in data.columns if c.lower() == 'id' or c.lower().endswith('_id')]
+            if id_cols:
+                data = data.drop(columns=id_cols, errors='ignore')
+        return data
+
+    @staticmethod
     def _try_template_response(state: AgentState) -> Optional[str]:
         """
         Try to generate a response from templates without an LLM call.
@@ -1212,6 +1553,11 @@ class AFLAnalyticsAgent:
         teams = entities.get("teams", [])
         players = entities.get("players", [])
         seasons = entities.get("seasons", [])
+
+        # Strip ID columns to prevent leaking DB IDs in responses
+        import pandas as pd
+        if isinstance(data, pd.DataFrame):
+            data = AFLAnalyticsAgent._strip_id_columns(data)
 
         # Handle empty results for tool-based intents with helpful messages
         if data is None or len(data) == 0:
@@ -1342,7 +1688,6 @@ class AFLAnalyticsAgent:
                 return f"{winner} defeated {away_team if winner == home_team else home_team} {max(home_score, away_score)}-{min(home_score, away_score)} by {margin} points{venue_text}{round_text}."
 
             numeric_cols = data.select_dtypes(include=['number']).columns.tolist()
-            # Check for name columns in the result (player_name, winner, team, name)
             name_cols = [c for c in data.columns if c.lower() in ['name', 'player', 'player_name', 'team', 'team_name', 'winner']]
 
             def _fmt_val(v):
@@ -1352,41 +1697,42 @@ class AFLAnalyticsAgent:
                     return f"{v:.1f}"
                 return str(v)
 
+            # Get subject from: 1) name column in result, 2) entities, 3) empty
+            subject = ""
+            if name_cols:
+                subject = str(row[name_cols[0]])
+            elif players:
+                subject = players[0]
+            elif teams:
+                subject = teams[0]
+
+            season_str = f" in {seasons[0]}" if seasons else ""
+
             if len(numeric_cols) == 1:
                 col = numeric_cols[0]
                 value = row[col]
-                col_label = col.replace("_", " ")
-
-                # Try to get subject from: 1) name column in result, 2) entities, 3) empty
-                subject = ""
-                if name_cols:
-                    subject = str(row[name_cols[0]])
-                elif players:
-                    subject = players[0]
-                elif teams:
-                    subject = teams[0]
-
-                season_str = f" in {seasons[0]}" if seasons else ""
+                label = AFLAnalyticsAgent._humanize_value_label(col)
 
                 if subject:
-                    return f"{subject} had {_fmt_val(value)} {col_label}{season_str}."
+                    # Natural phrasing based on the metric type
+                    val_str = _fmt_val(value)
+                    if any(w in label for w in ["wins", "losses", "finishes", "games"]):
+                        return f"{subject} had {val_str} {label}{season_str}."
+                    elif "average" in label or "avg" in label:
+                        return f"{subject} averaged {val_str} {label.replace('average ', '')}{season_str}."
+                    elif "rate" in label or "percentage" in label:
+                        return f"{subject} had a {val_str}% {label}{season_str}."
+                    else:
+                        return f"{subject} had {val_str} {label}{season_str}."
                 else:
-                    return f"The result is {_fmt_val(value)} {col_label}{season_str}."
+                    label = AFLAnalyticsAgent._humanize_value_label(col)
+                    return f"The {label}{season_str} is {_fmt_val(value)}."
 
             elif 2 <= len(numeric_cols) <= 5:
-                # Try to get subject from: 1) name column in result, 2) entities, 3) empty
-                subject = ""
-                if name_cols:
-                    subject = str(row[name_cols[0]])
-                elif players:
-                    subject = players[0]
-                elif teams:
-                    subject = teams[0]
-
-                season_str = f" in {seasons[0]}" if seasons else ""
                 parts = []
                 for col in numeric_cols:
-                    parts.append(f"{_fmt_val(row[col])} {col.replace('_', ' ')}")
+                    label = AFLAnalyticsAgent._humanize_value_label(col)
+                    parts.append(f"{_fmt_val(row[col])} {label}")
                 stats_str = ", ".join(parts)
                 if subject:
                     return f"{subject}{season_str}: {stats_str}."
@@ -1461,8 +1807,19 @@ class AFLAnalyticsAgent:
                             vals.append(str(v))
                     lines.append(f"| {i+1} | " + " | ".join(vals) + " |")
 
-                metric_label = numeric_cols[0].replace("_", " ")
-                header = f"Top {metric_label}{season_str}:\n\n"
+                metric_label = AFLAnalyticsAgent._humanize_value_label(numeric_cols[0])
+                # Try to derive a meaningful header from the query context
+                # Check if all rows are the same player (per-game breakdown, not a ranking)
+                unique_names = data[name_col].nunique() if name_col in data.columns else 0
+                if unique_names == 1:
+                    player_name = str(data.iloc[0][name_col])
+                    header = f"{player_name}'s game-by-game stats{season_str}:\n\n"
+                elif players and len(players) >= 2:
+                    header = f"{' vs '.join(players[:3])}{season_str}:\n\n"
+                elif teams and len(teams) >= 2:
+                    header = f"{' vs '.join(teams[:3])}{season_str}:\n\n"
+                else:
+                    header = f"Top {metric_label}{season_str}:\n\n"
                 return header + "\n".join(lines)
 
             # Fallback: any multi-row DataFrame with 3+ columns → auto markdown table
@@ -1506,23 +1863,129 @@ class AFLAnalyticsAgent:
         # --- PATTERN 3: Chart accompaniment (very brief text) ---
         if has_chart:
             subject = players[0] if players else teams[0] if teams else "the data"
-            season_str = f" ({seasons[0]})" if seasons else ""
             intent_str = str(intent).upper() if intent else ""
+            chart_data = state.get("query_results")
+
+            # Try to extract time range from the data
+            time_range = ""
+            if chart_data is not None and "season" in chart_data.columns:
+                seasons_in_data = sorted(chart_data["season"].unique())
+                if len(seasons_in_data) > 1:
+                    time_range = f" from {int(seasons_in_data[0])} to {int(seasons_in_data[-1])}"
+                elif len(seasons_in_data) == 1:
+                    time_range = f" in {int(seasons_in_data[0])}"
+            elif seasons:
+                time_range = f" in {seasons[0]}" if len(seasons) == 1 else f" from {seasons[0]} to {seasons[-1]}"
+
+            # Detect the chart type for a more descriptive accompaniment
+            viz_spec = state.get("visualization_spec", {})
+            viz_traces = viz_spec.get("data", []) if isinstance(viz_spec, dict) else []
+            chart_type_name = viz_traces[0].get("type", "") if viz_traces else ""
 
             if "TREND" in intent_str:
-                # Distinguish per-game (round-level) from multi-season trends
-                has_round_col = state.get("query_results") is not None and "round" in state["query_results"].columns
-                season_count = state["query_results"]["season"].nunique() if (state.get("query_results") is not None and "season" in state["query_results"].columns) else 0
+                has_round_col = chart_data is not None and "round" in chart_data.columns
+                season_count = chart_data["season"].nunique() if (chart_data is not None and "season" in chart_data.columns) else 0
                 if has_round_col and season_count <= 1:
-                    return f"Here's {subject}'s game-by-game stats{season_str}."
-                return f"Here's {subject}'s trend over time{season_str}."
+                    return f"Here's {subject}'s game-by-game performance{time_range}."
+                return f"Here's how {subject}'s numbers have changed{time_range}."
             elif "COMPARISON" in intent_str:
                 compared = " and ".join(players[:3]) if players else "the players"
-                return f"Here's a comparison of {compared}{season_str}. See the chart for the full breakdown."
+                return f"Here's a head-to-head comparison of {compared}{time_range}."
             elif "TEAM" in intent_str:
-                return f"Here's {subject}'s performance breakdown{season_str}."
+                return f"Here's {subject}'s performance breakdown{time_range}."
+            elif chart_type_name == "pie":
+                # Describe what the pie chart shows
+                numeric_cols = chart_data.select_dtypes(include=['number']).columns.tolist() if chart_data is not None else []
+                metric = AFLAnalyticsAgent._humanize_value_label(numeric_cols[0]) if numeric_cols else "breakdown"
+                return f"Here's {subject}'s {metric} breakdown{time_range}."
+            elif chart_type_name == "box":
+                return f"Here's the distribution of {subject}'s stats{time_range}."
             else:
-                return f"Here are the results for {subject}{season_str}."
+                # Generic but still descriptive
+                return f"Here's {subject}'s data{time_range}."
+
+        return None
+
+    @staticmethod
+    def _needs_data_range_disclaimer(state: Dict[str, Any]) -> bool:
+        """Check if the response should include a data range disclaimer."""
+        entities = state.get("entities", {})
+        seasons = entities.get("seasons", [])
+        user_query = state.get("user_query", "").lower()
+
+        # If user specified a season, no disclaimer needed
+        if seasons:
+            return False
+
+        # Check for all-time/historical indicators
+        all_time_keywords = ["all-time", "all time", "ever", "most", "record", "history",
+                             "career", "total", "highest ever", "best ever", "worst ever"]
+        return any(kw in user_query for kw in all_time_keywords)
+
+    @staticmethod
+    def _generate_follow_up(state: Dict[str, Any]) -> Optional[str]:
+        """Generate contextual follow-up suggestions based on the query result."""
+        import pandas as pd
+
+        data = state.get("query_results")
+        entities = state.get("entities", {})
+        intent = state.get("intent")
+        teams = entities.get("teams", [])
+        players = entities.get("players", [])
+        seasons = entities.get("seasons", [])
+
+        if not isinstance(data, pd.DataFrame) or len(data) < 2:
+            return None
+
+        # Only add follow-ups for list/table results
+        name_cols = [c for c in data.columns if c.lower() in ['name', 'player', 'player_name']]
+        team_cols = [c for c in data.columns if c.lower() in ['team', 'team_name']]
+
+        import random
+
+        # Top-N player list → suggest comparing top 2
+        if name_cols and len(data) >= 2:
+            p1 = str(data.iloc[0][name_cols[0]])
+            p2 = str(data.iloc[1][name_cols[0]])
+            season_str = f" in {seasons[0]}" if seasons else ""
+            prompts = [
+                f"Curious how {p1} and {p2} compare{season_str}? Just ask.",
+                f"Want to dig deeper? You could compare {p1} and {p2}, or check out {p1}'s full career.",
+                f"You could also compare {p1} and {p2} head-to-head{season_str}.",
+            ]
+            return random.choice(prompts)
+
+        # Team record → suggest comparison or previous season
+        if teams and len(teams) == 1:
+            team = teams[0]
+            if seasons:
+                prev_year = str(int(seasons[0]) - 1)
+                prompts = [
+                    f"Want to see how {team} went in {prev_year} for comparison?",
+                    f"I can also show you {team}'s scoring trend over time if you're interested.",
+                    f"You could also look at {team}'s {prev_year} season to compare.",
+                ]
+            else:
+                prompts = [
+                    f"I can also chart {team}'s performance over time if you'd like.",
+                    f"Want to see {team}'s scoring trend across seasons?",
+                ]
+            return random.choice(prompts)
+
+        # Player stats → suggest career or comparison
+        if players and len(players) == 1:
+            player = players[0]
+            if seasons:
+                prompts = [
+                    f"I can also pull up {player}'s full career numbers if you're interested.",
+                    f"Want to see how {player} stacks up against the rest of the league in {seasons[0]}?",
+                ]
+            else:
+                prompts = [
+                    f"Want to see {player}'s season-by-season breakdown?",
+                    f"I can also compare {player} against other players if you'd like.",
+                ]
+            return random.choice(prompts)
 
         return None
 
@@ -1555,39 +2018,14 @@ class AFLAnalyticsAgent:
                 error_detail = state.get("execution_error", "Unknown error")
                 logger.error(f"RESPOND: execution_error detected: {error_detail}")
 
-                state["natural_language_summary"] = (
-                    "I wasn't able to find an answer for that query. "
-                    "Try rephrasing your question, or if you think this data should be available, "
-                    "raise a request using the report button and I'll look into it."
-                )
+                state["natural_language_summary"] = self._build_error_response(state)
                 state["confidence"] = 0.0
-                logger.info(f"RESPOND: Returning error response with debug info")
+                logger.info(f"RESPOND: Returning error response")
                 return state
 
             # Check if we have results
             if state.get("query_results") is None or len(state["query_results"]) == 0:
-                raw_query = state.get("user_query", "")
-                suggestions = []
-
-                if state.get("needs_clarification"):
-                    suggestions.append(state.get("clarification_question", ""))
-
-                if "entities" in state and "teams" in state["entities"]:
-                    if not state["entities"]["teams"]:
-                        suggestions.append(
-                            f"Available teams: Adelaide, Brisbane Lions, Carlton, Collingwood, Essendon, "
-                            f"Fremantle, Geelong, Gold Coast, GWS, Hawthorn, Melbourne, North Melbourne, "
-                            f"Port Adelaide, Richmond, St Kilda, Sydney, West Coast, Western Bulldogs"
-                        )
-
-                suggestion_text = " ".join(suggestions) if suggestions else (
-                    "Try rephrasing your question or check that team/player names are correct."
-                )
-
-                state["natural_language_summary"] = (
-                    f"I couldn't find any data matching your query. {suggestion_text}"
-                    "\n\nIf you think this data should be available, raise a request using the report button and I'll look into it."
-                )
+                state["natural_language_summary"] = self._build_empty_results_response(state)
                 state["confidence"] = 0.3
                 return state
 
@@ -1636,6 +2074,16 @@ class AFLAnalyticsAgent:
             # Try template response first (avoids LLM call for simple queries)
             template_response = self._try_template_response(state)
             if template_response is not None:
+                # Add data range disclaimer for all-time queries
+                if self._needs_data_range_disclaimer(state):
+                    from app.data.database import get_data_recency
+                    _dr = get_data_recency()
+                    template_response += f"\n\n*Based on data from {_dr['earliest_season']} to present.*"
+                # Add follow-up suggestions for list/table responses (not charts — the chart speaks for itself)
+                if not state.get("visualization_spec"):
+                    follow_up = self._generate_follow_up(state)
+                    if follow_up:
+                        template_response += f"\n\n{follow_up}"
                 state["natural_language_summary"] = template_response
                 state["confidence"] = 0.9
                 from app.data.database import get_data_recency
@@ -1711,7 +2159,7 @@ class AFLAnalyticsAgent:
             query_lower = state['user_query'].lower()
             is_breakdown_query = any(term in query_lower for term in ['by round', 'round by round', 'each round', 'per round', 'breakdown', 'by game', 'by match'])
 
-            results_df = state['query_results']
+            results_df = self._strip_id_columns(state['query_results'])
             if is_breakdown_query or len(results_df) <= 50:
                 # Show all results for breakdown queries or smaller result sets
                 results_text = results_df.to_string()
@@ -1750,7 +2198,7 @@ CRITICAL RULES:
 - State the number/fact directly
 - DO NOT mention what additional analysis you could do
 - DO NOT mention limitations or missing data unless the query CANNOT be answered
-- DO NOT offer follow-up analysis unprompted
+- After answering, you may suggest 1 brief follow-up the user might find interesting. Keep it casual and conversational — NOT "Try: 'query'" format. Instead, something like "I can also show you X if you're interested." or "Want to see how that compares to Y?"
 - When presenting multiple rows of data, format as a markdown table
 
 {conversation_context_text}User asked: {state['user_query']}
@@ -1810,7 +2258,11 @@ Provide a concise analysis (3-5 sentences):"""
                 reasoning_effort="low",
             )
 
-            state["natural_language_summary"] = (response.choices[0].message.content or "").strip()
+            llm_response = (response.choices[0].message.content or "").strip()
+            # Add data range disclaimer for all-time queries
+            if self._needs_data_range_disclaimer(state):
+                llm_response += f"\n\n*Based on data from {_earliest} to present.*"
+            state["natural_language_summary"] = llm_response
             state["confidence"] = 0.9
             state["sources"] = [f"AFL Tables ({_earliest}-{_hist_season})"]
             state["thinking_message"] = "Response complete"

--- a/backend/app/agent/tools.py
+++ b/backend/app/agent/tools.py
@@ -125,6 +125,7 @@ class DatabaseTool:
             return {
                 "success": False,
                 "error": safe_msg,
+                "raw_error": error_msg,
                 "data": None,
                 "rows_returned": 0
             }

--- a/backend/app/analytics/entity_resolver.py
+++ b/backend/app/analytics/entity_resolver.py
@@ -447,6 +447,81 @@ class EntityResolver:
         return cls.TEAM_NICKNAMES.get(canonical_name, [])
 
 
+# Venue alias resolution
+class VenueResolver:
+    """Resolves venue aliases to canonical database names."""
+
+    VENUE_ALIASES = {
+        "M.C.G.": [
+            "mcg", "m.c.g.", "melbourne cricket ground", "the mcg", "the g"
+        ],
+        "Marvel Stadium": [
+            "marvel stadium", "marvel", "docklands", "etihad stadium", "etihad",
+            "colonial stadium", "telstra dome", "docklands stadium"
+        ],
+        "GMHBA Stadium": [
+            "gmhba stadium", "gmhba", "kardinia park", "simonds stadium",
+            "skilled stadium", "geelong", "kardinia"
+        ],
+        "Gabba": [
+            "gabba", "the gabba", "woolloongabba", "brisbane cricket ground"
+        ],
+        "S.C.G.": [
+            "scg", "s.c.g.", "sydney cricket ground", "the scg"
+        ],
+        "Optus Stadium": [
+            "optus stadium", "optus", "perth stadium", "perth"
+        ],
+        "Adelaide Oval": [
+            "adelaide oval", "adelaide"
+        ],
+        "People First Stadium": [
+            "people first stadium", "metricon stadium", "metricon", "carrara",
+            "heritage bank stadium"
+        ],
+        "Blundstone Arena": [
+            "blundstone arena", "blundstone", "bellerive oval", "bellerive"
+        ],
+        "UNSW Canberra Oval": [
+            "unsw canberra oval", "manuka oval", "manuka", "canberra"
+        ],
+        "TIO Traeger Park": [
+            "tio traeger park", "traeger park", "alice springs"
+        ],
+        "Sydney Showground Stadium": [
+            "sydney showground", "showground", "giants stadium", "engie stadium"
+        ],
+        "TIO Stadium": [
+            "tio stadium", "marrara oval", "darwin"
+        ],
+    }
+
+    _ALIAS_LOOKUP = None
+
+    @classmethod
+    def _build_lookup(cls):
+        if cls._ALIAS_LOOKUP is None:
+            cls._ALIAS_LOOKUP = {}
+            for canonical, aliases in cls.VENUE_ALIASES.items():
+                for alias in aliases:
+                    cls._ALIAS_LOOKUP[alias.lower()] = canonical
+
+    @classmethod
+    def resolve_venue(cls, user_input: str) -> Optional[str]:
+        """Resolve a venue name from user input to canonical database name."""
+        if not user_input:
+            return None
+        cls._build_lookup()
+        normalized = user_input.strip().lower()
+        if normalized in cls._ALIAS_LOOKUP:
+            return cls._ALIAS_LOOKUP[normalized]
+        # Try fuzzy partial match
+        for alias, canonical in cls._ALIAS_LOOKUP.items():
+            if alias in normalized or normalized in alias:
+                return canonical
+        return None
+
+
 # Metric normalization
 class MetricResolver:
     """Resolves metric aliases to canonical metric names."""

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -393,47 +393,45 @@ def get_upcoming_matches():
         from datetime import datetime
         from zoneinfo import ZoneInfo
 
-        # Fetch from Squiggle API
         current_year = datetime.now().year
-        response = requests.get(
-            f"https://api.squiggle.com.au/?q=games;year={current_year}",
-            headers={"User-Agent": "AFL-Analytics-App/1.0 (kyllhutchens@gmail.com)"},
-            timeout=10
-        )
-
-        if response.status_code != 200:
-            return jsonify({'error': 'Failed to fetch from Squiggle'}), 500
-
-        data = response.json()
-        games = data.get('games', [])
-
-        # Filter for upcoming games (not started yet)
-        # Get current time in Australian timezone for accurate comparison
         aus_tz = ZoneInfo('Australia/Melbourne')
         now = datetime.now(aus_tz)
-        upcoming = []
 
-        for game in games:
-            # Parse date
+        # Determine the current/next round from live_games DB to avoid fetching all 200+ games
+        from app.data.database import get_data_recency
+        recency = get_data_recency()
+        live_round = recency.get("live_latest_round")
+
+        # Fetch only the next 2 rounds from Squiggle (much faster than full season)
+        all_games = []
+        start_round = int(live_round) + 1 if live_round else 1
+        for r in range(start_round, start_round + 2):
+            try:
+                resp = requests.get(
+                    f"https://api.squiggle.com.au/?q=games;year={current_year};round={r}",
+                    headers={"User-Agent": "AFL-Analytics-App/1.0 (kyllhutchens@gmail.com)"},
+                    timeout=10
+                )
+                if resp.status_code == 200:
+                    all_games.extend(resp.json().get('games', []))
+            except Exception as round_err:
+                logger.warning(f"Failed to fetch round {r} from Squiggle: {round_err}")
+
+        upcoming = []
+        for game in all_games:
             date_str = game.get('date')
             if not date_str:
                 continue
 
             try:
-                # Squiggle returns dates in Australian Eastern time without timezone info
-                # Parse as naive datetime, then localize to Australian timezone
                 if 'Z' in date_str or '+' in date_str:
-                    # Already has timezone info
                     game_date = datetime.fromisoformat(date_str.replace('Z', '+00:00'))
                 else:
-                    # No timezone info - assume Australian Eastern time
                     naive_date = datetime.fromisoformat(date_str)
                     game_date = naive_date.replace(tzinfo=aus_tz)
             except (ValueError, AttributeError):
                 continue
 
-            # Only include games that haven't started yet
-            # A game has started if: complete > 0 OR current time > game time
             complete = game.get('complete', 0)
             if complete == 0 and game_date > now:
                 upcoming.append({
@@ -442,12 +440,11 @@ def get_upcoming_matches():
                     'home_team': game.get('hteam'),
                     'away_team': game.get('ateam'),
                     'venue': game.get('venue'),
-                    'date': game_date.isoformat(),  # Now includes timezone info
+                    'date': game_date.isoformat(),
                     'complete': complete,
                     'is_final': game.get('is_final', False),
                 })
 
-        # Sort by date (earliest first)
         upcoming.sort(key=lambda x: x['date'])
 
         # Attach Squiggle predictions

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -384,10 +384,18 @@ def _attach_predictions(upcoming: list, season: int):
         logger.debug(f"Failed to attach predictions: {e}")
 
 
+_upcoming_cache = {"data": None, "expires": 0}
+
 @bp.route('/upcoming-matches', methods=['GET'])
 @limiter.exempt  # Exempt from rate limiting (polled frequently)
 def get_upcoming_matches():
     """Get upcoming scheduled AFL matches from Squiggle API."""
+    import time as _time
+
+    # Return cached data if fresh (2 min TTL)
+    if _upcoming_cache["data"] is not None and _time.time() < _upcoming_cache["expires"]:
+        return jsonify(_upcoming_cache["data"]), 200
+
     try:
         import requests
         from datetime import datetime
@@ -457,10 +465,17 @@ def get_upcoming_matches():
         for match in upcoming:
             match['preview'] = previews.get(match['id'])
 
-        return jsonify({'matches': upcoming}), 200
+        result = {'matches': upcoming}
+        _upcoming_cache["data"] = result
+        _upcoming_cache["expires"] = _time.time() + 120  # 2 min TTL
+
+        return jsonify(result), 200
 
     except Exception as e:
         logger.error(f"Error fetching upcoming matches: {e}")
+        # Return stale cache if available, otherwise empty
+        if _upcoming_cache["data"] is not None:
+            return jsonify(_upcoming_cache["data"]), 200
         return jsonify({'matches': [], 'error': 'Squiggle API unavailable'}), 200
 
 

--- a/backend/app/data/ingestion/stats_ingester.py
+++ b/backend/app/data/ingestion/stats_ingester.py
@@ -567,6 +567,21 @@ def _build_team_name_cache(session) -> Dict[str, int]:
         if simple not in cache:
             cache[simple] = team.id
 
+    # Priority 3: historical team name aliases
+    _ALIASES = {
+        "kangaroos": "North Melbourne",
+        "the kangaroos": "North Melbourne",
+        "footscray": "Western Bulldogs",
+        "south melbourne": "Sydney",
+        "fitzroy": "Brisbane Lions",
+        "bears": "Brisbane Lions",
+        "brisbane bears": "Brisbane Lions",
+    }
+    for alias, canonical in _ALIASES.items():
+        canonical_lower = canonical.lower()
+        if canonical_lower in cache and alias not in cache:
+            cache[alias] = cache[canonical_lower]
+
     return cache
 
 

--- a/backend/app/utils/cache.py
+++ b/backend/app/utils/cache.py
@@ -1,16 +1,27 @@
 """
-Simple in-memory query cache to reduce redundant OpenAI calls.
+Simple in-memory query cache to reduce redundant database calls.
 Caches SQL query results by a hash of the SQL string.
-TTL: 5 minutes, Max: 100 entries
+
+Two-tier caching:
+- Historical (queries referencing only past seasons): TTL 60 min, 500 entries
+- Live/current-season: TTL 5 min, 100 entries
 """
 import hashlib
 import logging
+import re
+from datetime import datetime
 from cachetools import TTLCache
 
 logger = logging.getLogger(__name__)
 
-# 5-minute TTL, 100 entries max
-query_cache: TTLCache = TTLCache(maxsize=100, ttl=300)
+# Historical data cache: long TTL since past seasons don't change
+_historical_cache: TTLCache = TTLCache(maxsize=500, ttl=3600)  # 60 min
+
+# Live/current-season cache: short TTL for fresh data
+_live_cache: TTLCache = TTLCache(maxsize=100, ttl=300)  # 5 min
+
+# Current year for cache routing
+_CURRENT_YEAR = datetime.now().year
 
 
 def get_cache_key(sql: str) -> str:
@@ -18,26 +29,61 @@ def get_cache_key(sql: str) -> str:
     return hashlib.md5(sql.strip().lower().encode()).hexdigest()
 
 
+def _is_historical_query(sql: str) -> bool:
+    """Determine if a SQL query only references past seasons (safe for long caching)."""
+    sql_lower = sql.lower()
+
+    # If it references live_games, it's always live
+    if 'live_games' in sql_lower:
+        return False
+
+    # Extract all year references from the SQL
+    years = re.findall(r'\b((?:19|20)\d{2})\b', sql)
+    if not years:
+        return False  # No years = can't determine, use short TTL
+
+    # If ALL referenced years are before current year, it's historical
+    return all(int(y) < _CURRENT_YEAR for y in years)
+
+
 def get_cached_result(sql: str):
     """Return cached DataFrame result for this SQL, or None if not cached."""
     key = get_cache_key(sql)
-    result = query_cache.get(key)
+
+    # Check historical cache first (larger, longer TTL)
+    result = _historical_cache.get(key)
     if result is not None:
-        logger.debug(f"Cache hit for query hash {key[:8]}")
-    return result
+        logger.debug(f"Cache hit (historical) for query hash {key[:8]}")
+        return result
+
+    # Then check live cache
+    result = _live_cache.get(key)
+    if result is not None:
+        logger.debug(f"Cache hit (live) for query hash {key[:8]}")
+        return result
+
+    return None
 
 
 def set_cached_result(sql: str, result) -> None:
-    """Store a DataFrame result in the cache."""
+    """Store a DataFrame result in the appropriate cache bucket."""
     key = get_cache_key(sql)
-    query_cache[key] = result
-    logger.debug(f"Cached result for query hash {key[:8]} ({len(result)} rows)")
+
+    if _is_historical_query(sql):
+        _historical_cache[key] = result
+        logger.debug(f"Cached result (historical, 60min TTL) for hash {key[:8]} ({len(result)} rows)")
+    else:
+        _live_cache[key] = result
+        logger.debug(f"Cached result (live, 5min TTL) for hash {key[:8]} ({len(result)} rows)")
 
 
 def cache_stats() -> dict:
     """Return current cache statistics."""
     return {
-        "size": len(query_cache),
-        "maxsize": query_cache.maxsize,
-        "ttl": query_cache.ttl,
+        "historical_size": len(_historical_cache),
+        "historical_maxsize": _historical_cache.maxsize,
+        "historical_ttl": _historical_cache.ttl,
+        "live_size": len(_live_cache),
+        "live_maxsize": _live_cache.maxsize,
+        "live_ttl": _live_cache.ttl,
     }

--- a/backend/app/visualization/chart_selector.py
+++ b/backend/app/visualization/chart_selector.py
@@ -8,6 +8,7 @@ from typing import Dict, Any, Optional, List
 import pandas as pd
 import logging
 import json
+import re
 from openai import OpenAI
 import os
 
@@ -39,6 +40,26 @@ class ChartSelector:
         "box": "Shows distribution and outliers. Best for statistical analysis.",
     }
 
+    # Regex patterns for explicit chart type requests
+    _EXPLICIT_CHART_PATTERNS = [
+        (re.compile(r'\bpie\s+chart\b', re.IGNORECASE), "pie"),
+        (re.compile(r'\bscatter\s+(?:plot|chart|graph)\b', re.IGNORECASE), "scatter"),
+        (re.compile(r'\bbox\s+(?:plot|chart|graph)\b', re.IGNORECASE), "box"),
+        (re.compile(r'\bhorizontal\s+bar\s*(?:chart|graph)?\b', re.IGNORECASE), "horizontal_bar"),
+        (re.compile(r'\bstacked\s+bar\s*(?:chart|graph)?\b', re.IGNORECASE), "stacked_bar"),
+        (re.compile(r'\bgrouped\s+bar\s*(?:chart|graph)?\b', re.IGNORECASE), "grouped_bar"),
+        (re.compile(r'\bline\s+(?:chart|graph|plot)\b', re.IGNORECASE), "line"),
+        (re.compile(r'\bbar\s+(?:chart|graph|plot)\b', re.IGNORECASE), "bar"),
+    ]
+
+    @classmethod
+    def _detect_explicit_chart_type(cls, user_query: str) -> Optional[str]:
+        """Detect if user explicitly requested a specific chart type."""
+        for pattern, chart_type in cls._EXPLICIT_CHART_PATTERNS:
+            if pattern.search(user_query):
+                return chart_type
+        return None
+
     @classmethod
     def select_chart_configuration(
         cls,
@@ -67,6 +88,29 @@ class ChartSelector:
             - reasoning: str (why this chart was chosen)
         """
         try:
+            # Check for explicit chart type request from user FIRST
+            explicit_type = cls._detect_explicit_chart_type(user_query)
+            if explicit_type:
+                logger.info(f"Chart selection via explicit user request: {explicit_type}")
+                # Infer x/y columns
+                numeric_cols = [c for c in data.select_dtypes(include=['number']).columns.tolist()
+                                if 'id' not in c.lower() and c not in ('season', 'year')]
+                non_numeric = data.select_dtypes(exclude=['number']).columns.tolist()
+                temporal_cols = [c for c in data.columns if c in ['season', 'year', 'match_date', 'round']]
+
+                x_col = temporal_cols[0] if temporal_cols else (non_numeric[0] if non_numeric else data.columns[0])
+                y_col = numeric_cols[0] if numeric_cols else data.columns[-1]
+
+                return {
+                    "chart_type": explicit_type,
+                    "x_col": x_col,
+                    "y_col": y_col,
+                    "group_col": None,
+                    "reasoning": f"User explicitly requested {explicit_type} chart",
+                    "confidence": "high",
+                    "user_explicit": True,
+                }
+
             # Quick heuristics for obvious cases (covers ~90% of queries)
             quick_result = cls._quick_heuristics(data, intent, entities, user_query)
             if quick_result:

--- a/backend/app/visualization/plotly_builder.py
+++ b/backend/app/visualization/plotly_builder.py
@@ -432,6 +432,22 @@ class PlotlyBuilder:
             elif chart_type == "scatter":
                 return PlotlyBuilder._build_scatter_chart(data, params)
 
+            elif chart_type == "horizontal_bar":
+                params["orientation"] = "h"
+                return PlotlyBuilder._build_bar_chart(data, params)
+
+            elif chart_type == "pie":
+                return PlotlyBuilder._build_pie_chart(data, params)
+
+            elif chart_type == "box":
+                return PlotlyBuilder._build_box_chart(data, params)
+
+            elif chart_type == "stacked_bar":
+                return PlotlyBuilder._build_multi_bar_chart(data, params, barmode="stack")
+
+            elif chart_type == "grouped_bar":
+                return PlotlyBuilder._build_multi_bar_chart(data, params, barmode="group")
+
             elif chart_type == "comparison":
                 return PlotlyBuilder._build_comparison_chart(data, params)
 
@@ -773,6 +789,151 @@ class PlotlyBuilder:
                 return None
             else:
                 return obj
+
+        return clean_nan(fig_dict)
+
+    @staticmethod
+    def _build_pie_chart(data: pd.DataFrame, params: Dict) -> Dict:
+        """Build a pie chart for proportions."""
+        x_col = params.get("x_col", data.columns[0])
+        y_col = params.get("y_col", data.columns[1])
+        title = params.get("title", "Distribution")
+
+        traces = [go.Pie(
+            labels=data[x_col].tolist(),
+            values=data[y_col].tolist(),
+            marker={"colors": PlotlyBuilder.COLOR_SEQUENCE},
+            textinfo="percent+label",
+            hole=0.3,
+        )]
+
+        layout = PlotlyBuilder.BASE_LAYOUT.copy()
+        layout["title"] = {
+            "text": title,
+            "x": 0.5,
+            "xanchor": "center",
+            "font": {"size": 18},
+            "pad": {"b": 20}
+        }
+        layout["showlegend"] = True
+
+        fig = go.Figure(data=traces, layout=layout)
+        fig_dict = fig.to_dict()
+
+        import math
+        def clean_nan(obj):
+            if isinstance(obj, dict):
+                return {k: clean_nan(v) for k, v in obj.items()}
+            elif isinstance(obj, list):
+                return [clean_nan(item) for item in obj]
+            elif isinstance(obj, float) and math.isnan(obj):
+                return None
+            return obj
+
+        return clean_nan(fig_dict)
+
+    @staticmethod
+    def _build_box_chart(data: pd.DataFrame, params: Dict) -> Dict:
+        """Build a box plot for distributions."""
+        y_col = params.get("y_col", data.columns[-1])
+        group_col = params.get("group_col") or params.get("x_col")
+        title = params.get("title", "Distribution Analysis")
+
+        traces = []
+        if group_col and group_col in data.columns and data[group_col].nunique() <= 20:
+            for i, group in enumerate(data[group_col].unique()):
+                group_data = data[data[group_col] == group]
+                traces.append(go.Box(
+                    y=group_data[y_col].tolist(),
+                    name=str(group),
+                    marker={"color": PlotlyBuilder.COLOR_SEQUENCE[i % len(PlotlyBuilder.COLOR_SEQUENCE)]},
+                ))
+        else:
+            traces.append(go.Box(
+                y=data[y_col].tolist(),
+                name=ChartHelper.humanize_column_name(y_col),
+                marker={"color": PlotlyBuilder.COLORS["primary"]},
+            ))
+
+        layout = PlotlyBuilder.BASE_LAYOUT.copy()
+        layout["title"] = {
+            "text": title,
+            "x": 0.5,
+            "xanchor": "center",
+            "font": {"size": 18},
+            "pad": {"b": 20}
+        }
+        layout["yaxis"]["title"] = {"text": ChartHelper.humanize_column_name(y_col)}
+
+        fig = go.Figure(data=traces, layout=layout)
+        fig_dict = fig.to_dict()
+
+        import math
+        def clean_nan(obj):
+            if isinstance(obj, dict):
+                return {k: clean_nan(v) for k, v in obj.items()}
+            elif isinstance(obj, list):
+                return [clean_nan(item) for item in obj]
+            elif isinstance(obj, float) and math.isnan(obj):
+                return None
+            return obj
+
+        return clean_nan(fig_dict)
+
+    @staticmethod
+    def _build_multi_bar_chart(data: pd.DataFrame, params: Dict, barmode: str = "group") -> Dict:
+        """Build a stacked or grouped bar chart with multiple traces."""
+        x_col = params.get("x_col", data.columns[0])
+        group_col = params.get("group_col")
+        title = params.get("title", "Comparison")
+
+        numeric_cols = [c for c in data.select_dtypes(include=['number']).columns.tolist()
+                        if 'id' not in c.lower()]
+
+        traces = []
+        if group_col and group_col in data.columns:
+            y_col = params.get("y_col", numeric_cols[0] if numeric_cols else data.columns[-1])
+            for i, group in enumerate(data[group_col].unique()):
+                group_data = data[data[group_col] == group]
+                traces.append(go.Bar(
+                    x=group_data[x_col].tolist(),
+                    y=group_data[y_col].tolist(),
+                    name=str(group),
+                    marker={"color": PlotlyBuilder.COLOR_SEQUENCE[i % len(PlotlyBuilder.COLOR_SEQUENCE)]},
+                ))
+        else:
+            # Use multiple numeric columns as separate traces
+            for i, col in enumerate(numeric_cols[:6]):
+                traces.append(go.Bar(
+                    x=data[x_col].tolist(),
+                    y=data[col].tolist(),
+                    name=ChartHelper.humanize_column_name(col),
+                    marker={"color": PlotlyBuilder.COLOR_SEQUENCE[i % len(PlotlyBuilder.COLOR_SEQUENCE)]},
+                ))
+
+        layout = PlotlyBuilder.BASE_LAYOUT.copy()
+        layout["title"] = {
+            "text": title,
+            "x": 0.5,
+            "xanchor": "center",
+            "font": {"size": 18},
+            "pad": {"b": 20}
+        }
+        layout["barmode"] = barmode
+        layout["xaxis"]["title"] = {"text": ChartHelper.humanize_column_name(x_col)}
+
+        fig = go.Figure(data=traces, layout=layout)
+        fig_dict = fig.to_dict()
+
+        import math
+        def clean_nan(obj):
+            if isinstance(obj, dict):
+                return {k: clean_nan(v) for k, v in obj.items()}
+            elif isinstance(obj, list):
+                return [clean_nan(item) for item in obj]
+            elif isinstance(obj, float) and math.isnan(obj):
+                return None
+            return obj
 
         return clean_nan(fig_dict)
 

--- a/eval_queries.txt
+++ b/eval_queries.txt
@@ -1,0 +1,128 @@
+How many games has Collingwood won this season?
+Who kicked the most goals last round?
+Show me the top 10 disposal getters in 2025
+What was the score in the 2024 grand final?
+Who won the Brownlow Medal in 2023?
+How many premierships has Hawthorn won?
+Show me a chart of Melbourne's wins per season since 2018
+What's Dustin Martin's career goals tally?
+Who has the most tackles in the AFL this year?
+Compare disposals per game for Marcus Bontempelli and Patrick Cripps this season
+Which team has the best percentage in 2025?
+Show me a bar chart of goals kicked by each team in round 5
+What's the average winning margin in grand finals since 2000?
+Who holds the record for most marks in a single game?
+How has Brisbane's scoring changed quarter by quarter this season?
+List every Coleman Medal winner since 2010
+Which ground does Geelong have the best win rate at?
+Show me Patrick Dangerfield's disposal trend over his career season by season
+Who are the top 5 contested possession players in the league right now?
+What's Carlton's win-loss record against Essendon since 1990?
+Show me a pie chart of scoring sources - goals vs behinds for Sydney in 2024
+Which player has the most inside 50s this season?
+How does Tom Green's tackle rate compare to other midfielders?
+Show me a line chart of Fremantle's ladder position at the end of each season since 2010
+What's the biggest upset in terms of margin this season?
+Who has played the most consecutive games in AFL history?
+Show me Richmond's average attendance per season over the last decade
+What percentage of games does the home team win at the MCG?
+Compare Clayton Oliver and Andrew Brayshaw's stats side by side for 2024
+Which team gives up the most points per game this year?
+Show me a scatter plot of disposals vs fantasy points for all midfielders in 2025
+Who kicked 10 goals in a game most recently?
+What's the average number of goals per game in the AFL across each season since 2000?
+How many times has Geelong finished top 4 since 2007?
+Show me Nick Daicos's stats progression from his debut to now
+Which team has won the most games at Marvel Stadium?
+What's West Coast's record when scoring over 100 points?
+Who are the top 5 mark takers in the league this season?
+Show me a grouped bar chart comparing GWS and Western Bulldogs in goals, behinds, and points per game
+Has there ever been a drawn grand final?
+What's the longest winning streak by any team this century?
+How does Chad Warner's 2025 compare to his 2024 statistically?
+Show me every team's average margin of victory this season as a horizontal bar chart
+Which rookies have averaged the most disposals this year?
+What's the head-to-head record between Sydney and Collingwood in finals?
+Show me a stacked bar chart of contested vs uncontested possessions for the top 8 teams
+Who has the highest goal accuracy percentage this season with at least 15 goals?
+How many games has Touk Miller played and what's his career disposal average?
+What's the highest scoring game in AFL history?
+List the top 10 fantasy point scorers over the last 3 seasons combined
+Which team has improved the most from last season to this season in terms of wins?
+Show me a box plot of Zach Merrett's disposal counts across all games in 2024
+How does Port Adelaide perform in night games vs day games?
+Who has the most clearances in a single season since 2015?
+What are the average scores by quarter across the league this season?
+Show me a chart of North Melbourne's draft picks and where those players are now in terms of games played
+Compare Max Gawn and Brodie Grundy's hitout numbers over the past 5 seasons
+What's the most common winning margin range in the AFL?
+Which player has the best ratio of goals to behinds this year?
+How does Essendon's form in the first 6 rounds compare to their form after the bye historically?
+Show me the top disposal getters per round this season as a line chart tracking the leader over time
+Who has taken the most contested marks this year?
+What's Adelaide's record in games decided by less than a goal since 2020?
+How many times has a team come back from 40+ points down to win this decade?
+Show me a heatmap or grouped chart of each team's scoring by quarter this season
+Which key forward has the best goals-per-game average over their career with 100+ games?
+What was Jordan De Goey's best statistical game ever?
+How does St Kilda's percentage track across each round this season?
+Who are the leading goalkickers for each team this year?
+Show me a trend line of average game scores in the AFL from 1990 to present
+What's the youngest team by average age in the league right now?
+Compare Isaac Heeney's 2024 season to Lachie Neale's 2020 Brownlow year
+Which team has the most losses by under 6 points this season?
+How do teams that win the clearance count perform in terms of winning the game?
+Show me every Norm Smith Medal winner and their stats from that grand final
+What's Gold Coast's all-time record against every other team?
+Who has played the most games without a finals appearance?
+Show me a bar chart of brownlow votes by team this season
+How does the bye week affect team performance - do teams win more or less the week after?
+What's the scoring trend in the first quarter vs the last quarter across the league?
+Which players have kicked bags of 5+ goals multiple times this season?
+Compare the defensive stats of Sam Taylor and Steven May in 2024
+How has the average number of tackles per game changed over the last 20 years?
+Show me Hawthorn's scoring worm for their last game
+Who has the most one percenters this season?
+What's the record for most behinds kicked in a single match?
+Show me a chart comparing each team's home vs away win percentage this season
+Which midfielders average over 30 disposals and 5 tackles per game?
+How does playing on a Thursday night affect scoring compared to Saturday afternoon?
+List every Rising Star winner from the last 15 years and their career games played
+What's the biggest comeback in finals history?
+How do contested possession differential and match result correlate?
+Show me a scatter plot of inside 50s vs goals scored per game for all teams in 2025
+Who has the most clangers in the league this year?
+What's the average time on ground percentage for key position players vs midfielders?
+Compare Errol Gulden, Sam Walsh, and Caleb Serong across all major stat categories in 2025
+How many games have ended with a team scoring exactly 100 points this season?
+What's the win rate for teams that lead at three quarter time across the last 5 years?
+Show me a line chart of the number of free kicks per game over the last 30 years - has it gone up or down?
+Which team converts inside 50s to goals at the highest rate?
+How does rebound 50 count relate to winning percentage for each team this season?
+Give me a full statistical breakdown of the 2023 grand final - every player's stats
+Show me a chart of every team's average fantasy points per player ranked from highest to lowest
+What was the quarter by quarter score in the 2023 grand final?
+Who won the Coleman Medal in 2024?
+How many career goals has Tom Hawkins kicked?
+What happened in round 10 2024?
+What was the score in round 8 Carlton vs Collingwood 2024?
+Geelong vs Sydney results in 2023
+Show me a pie chart of wins by each team in the top 8 in 2024
+Give me a box plot of disposal counts for Cripps in 2024
+Show me a horizontal bar chart of the top 10 goal kickers in 2024
+Show me a stacked bar chart of goals and behinds for Melbourne in 2024
+What are the all-time most goals kicked in a season?
+Who has the best record at Kardinia Park since 2010?
+How have teams performed at the Gabba over the last 5 years?
+Which team has won the most games at Docklands?
+Who are the top midfielders by disposals in 2024?
+What's Collingwood's scoring in each quarter in the 2023 grand final?
+What was the halftime score in the 2022 grand final?
+Dustin Martin career stats
+Who kicked the most goals in round 3 2024?
+Show me Carlton's goal kickers in round 12 2024 as a bar chart
+What was the margin in the 2024 preliminary final between Sydney and Port Adelaide?
+How many games did Jeremy Cameron play in his career?
+Show me a scatter plot of marks vs goals for all players with 20+ goals in 2024
+Who has the most all-time Brownlow votes?
+What was the score at three quarter time in the 2024 grand final?

--- a/frontend/src/components/LiveGames/GameSidebar.tsx
+++ b/frontend/src/components/LiveGames/GameSidebar.tsx
@@ -201,7 +201,7 @@ const GameSidebar: React.FC<GameSidebarProps> = ({ games, selectedGameId, onSele
                 {/* Prediction */}
                 {match.prediction && match.prediction.margin != null && (
                   <div className="mt-1.5 text-[11px] text-apple-gray-500">
-                    Squiggle tips {match.prediction.winner} by {Math.round(match.prediction.margin)}
+                    Tipping {match.prediction.winner} by {Math.round(match.prediction.margin)}
                   </div>
                 )}
               </button>
@@ -251,7 +251,7 @@ const GameSidebar: React.FC<GameSidebarProps> = ({ games, selectedGameId, onSele
               </div>
               {match.prediction && match.prediction.margin != null && (
                 <div className="mt-1.5 text-[11px] text-apple-gray-500 truncate">
-                  Squiggle tips {match.prediction.winner} by {Math.round(match.prediction.margin)}
+                  Tipping {match.prediction.winner} by {Math.round(match.prediction.margin)}
                 </div>
               )}
             </button>

--- a/frontend/src/components/LiveGames/GameSidebar.tsx
+++ b/frontend/src/components/LiveGames/GameSidebar.tsx
@@ -137,6 +137,10 @@ const GameSidebar: React.FC<GameSidebarProps> = ({ games, selectedGameId, onSele
     ? upcomingMatches.filter(m => String(m.round) === String(currentRound))
     : [];
 
+  // Split upcoming into games with previews (shown higher) and without
+  const upcomingWithPreview = currentRoundUpcoming.filter(m => !!m.preview);
+  const upcomingWithoutPreview = currentRoundUpcoming.filter(m => !m.preview);
+
   // Find the next round number (first round after current)
   const nextRound = currentRound
     ? upcomingMatches.find(m => String(m.round) !== String(currentRound))?.round
@@ -279,9 +283,14 @@ const GameSidebar: React.FC<GameSidebarProps> = ({ games, selectedGameId, onSele
             </div>
           )}
 
+          {/* Upcoming with preview - shown above results */}
+          {upcomingWithPreview.length > 0 && (
+            <UpcomingList matches={upcomingWithPreview} label="Preview" />
+          )}
+
           {/* Results this round */}
           {completedGames.length > 0 && (
-            <div className={liveGames.length > 0 ? 'mt-4' : ''}>
+            <div className={liveGames.length > 0 || upcomingWithPreview.length > 0 ? 'mt-4' : ''}>
               <div className="mb-2 px-1">
                 <span className="text-xs font-semibold text-apple-gray-400 uppercase tracking-wide">Results</span>
               </div>
@@ -293,8 +302,10 @@ const GameSidebar: React.FC<GameSidebarProps> = ({ games, selectedGameId, onSele
             </div>
           )}
 
-          {/* Upcoming this round */}
-          <UpcomingList matches={currentRoundUpcoming} label="Upcoming" />
+          {/* Upcoming without preview */}
+          {upcomingWithoutPreview.length > 0 && (
+            <UpcomingList matches={upcomingWithoutPreview} label="Upcoming" />
+          )}
 
           {/* Next round */}
           {nextRoundUpcoming.length > 0 && (
@@ -316,14 +327,16 @@ const GameSidebar: React.FC<GameSidebarProps> = ({ games, selectedGameId, onSele
                 <GameTile game={game} />
               </div>
             ))}
+            {/* Then upcoming with preview */}
+            <MobileUpcomingTiles matches={upcomingWithPreview} />
             {/* Then completed this round */}
             {completedGames.map(game => (
               <div key={game.id} className="w-36 flex-shrink-0">
                 <GameTile game={game} />
               </div>
             ))}
-            {/* Then upcoming this round */}
-            <MobileUpcomingTiles matches={currentRoundUpcoming} />
+            {/* Then upcoming without preview */}
+            <MobileUpcomingTiles matches={upcomingWithoutPreview} />
             {/* Next round */}
             <MobileUpcomingTiles matches={nextRoundUpcoming} />
           </div>

--- a/frontend/src/components/LiveGames/GameSidebar.tsx
+++ b/frontend/src/components/LiveGames/GameSidebar.tsx
@@ -127,26 +127,24 @@ const GameSidebar: React.FC<GameSidebarProps> = ({ games, selectedGameId, onSele
     );
   };
 
-  // Determine the current round from live/completed games or earliest upcoming
-  const currentRound = liveGames[0]?.round
-    ?? completedGames[0]?.round
-    ?? (upcomingMatches.length > 0 ? String(upcomingMatches[0].round) : null);
+  // Games with previews — shown above results regardless of round
+  const upcomingWithPreview = upcomingMatches.filter(m => !!m.preview);
 
-  // Show only this round's remaining games + next round's games (no further)
-  const currentRoundUpcoming = currentRound
-    ? upcomingMatches.filter(m => String(m.round) === String(currentRound))
+  // Remaining upcoming without preview, grouped by round
+  const upcomingNoPreview = upcomingMatches.filter(m => !m.preview);
+  const firstUpcomingRound = upcomingNoPreview.length > 0 ? String(upcomingNoPreview[0].round) : null;
+  const upcomingWithoutPreview = firstUpcomingRound
+    ? upcomingNoPreview.filter(m => String(m.round) === firstUpcomingRound)
     : [];
 
-  // Split upcoming into games with previews (shown higher) and without
-  const upcomingWithPreview = currentRoundUpcoming.filter(m => !!m.preview);
-  const upcomingWithoutPreview = currentRoundUpcoming.filter(m => !m.preview);
-
-  // Find the next round number (first round after current)
-  const nextRound = currentRound
-    ? upcomingMatches.find(m => String(m.round) !== String(currentRound))?.round
-    : null;
+  // Next round (the round after the first upcoming round)
+  const nextRound = firstUpcomingRound
+    ? upcomingNoPreview.find(m => String(m.round) !== firstUpcomingRound)?.round ?? null
+    : (upcomingWithPreview.length > 0
+      ? upcomingMatches.find(m => !m.preview && String(m.round) !== String(upcomingWithPreview[0].round))?.round ?? null
+      : null);
   const nextRoundUpcoming = nextRound
-    ? upcomingMatches.filter(m => String(m.round) === String(nextRound))
+    ? upcomingMatches.filter(m => String(m.round) === String(nextRound) && !m.preview)
     : [];
 
   const UpcomingList: React.FC<{ matches: UpcomingMatch[]; label: string }> = ({ matches, label }) => {

--- a/frontend/src/components/LiveGames/GameSidebar.tsx
+++ b/frontend/src/components/LiveGames/GameSidebar.tsx
@@ -283,7 +283,7 @@ const GameSidebar: React.FC<GameSidebarProps> = ({ games, selectedGameId, onSele
 
           {/* Upcoming with preview - shown above results */}
           {upcomingWithPreview.length > 0 && (
-            <UpcomingList matches={upcomingWithPreview} label="Preview" />
+            <UpcomingList matches={upcomingWithPreview} label={`Round ${upcomingWithPreview[0].round} Preview`} />
           )}
 
           {/* Results this round */}

--- a/frontend/src/components/LiveGames/LiveDashboard.tsx
+++ b/frontend/src/components/LiveGames/LiveDashboard.tsx
@@ -107,10 +107,10 @@ const LiveDashboard: React.FC<LiveDashboardProps> = ({ gameId }) => {
         <GameStats gameId={game.id} gameStatus={game.status} />
       )}
 
-      {/* Quarter Summaries - shown when available */}
-      {!hideScores && hasQuarterSummaries && (
+      {/* Quarter Summaries - temporarily hidden while quality is improved */}
+      {/* {!hideScores && hasQuarterSummaries && (
         <QuarterSummaries quarterSummaries={game.quarter_summaries!} quarterScores={game.quarter_scores} />
-      )}
+      )} */}
 
       {/* AI Summary for completed games - hidden when spoiler mode is on */}
       {!hideScores && game.status === 'completed' && game.ai_summary && (

--- a/frontend/src/pages/LiveGames.tsx
+++ b/frontend/src/pages/LiveGames.tsx
@@ -157,7 +157,7 @@ const LiveGames = () => {
               {nextMatch.prediction && nextMatch.prediction.margin != null && (
                 <div className="text-center mb-4">
                   <span className="inline-flex items-center gap-2 px-4 py-2 bg-apple-blue-50 rounded-full text-sm font-medium text-apple-blue-700">
-                    Squiggle predicts {nextMatch.prediction.winner} by {Math.round(nextMatch.prediction.margin)} points
+                    Tipping {nextMatch.prediction.winner} by {Math.round(nextMatch.prediction.margin)} points
                     {nextMatch.prediction.home_prob != null && nextMatch.prediction.away_prob != null && (
                       <span className="text-apple-blue-500">
                         ({nextMatch.prediction.home_prob}% - {nextMatch.prediction.away_prob}%)
@@ -313,7 +313,7 @@ const LiveGames = () => {
                     <div className="flex items-center justify-between">
                       <div>
                         <h3 className="text-lg font-semibold text-apple-gray-900">
-                          Squiggle Prediction
+                          Match Prediction
                         </h3>
                         <p className="text-apple-gray-700 mt-1">
                           {selectedUpcoming.prediction.winner} by {Math.round(selectedUpcoming.prediction.margin)} points


### PR DESCRIPTION
## Summary

Addresses 8 eval failures from the 103-query eval run, adds performance improvements, improves response quality, and refines the Live Games tab.

### Agent Eval Fixes & Performance
- **8 eval bug fixes**: Strip leaked IDs, honour explicit chart types (pie/box/scatter/stacked/grouped bar), live_games fallback for current round, venue alias resolution, remove unpopulated position column, add quarter score columns + table list to LLM prompt, humanize response labels, add data range disclaimers
- **Fast-path expansion**: 6 new patterns (head-to-head, round results, match result, Coleman Medal, player career stats) + smart guards to prevent greedy matching on specific round/match/player-stat queries
- **Smarter caching**: Historical queries (60min TTL, 500 entries) vs live (5min, 100 entries); LLM cache 128→512
- **Better responses**: Conversational follow-up suggestions, descriptive chart accompaniment, suppress useless single-value charts, force viz on explicit chart requests, fix off-topic false positives
- **25 new eval queries** targeting all 9 improvements

### Live Games Tab
- **Hide quarter summaries** (keeping top performers + post-match summary) while quality is improved
- **Reorder sidebar**: Live → Round N Preview → Results → Upcoming → Next Round
- **Fix upcoming-matches timeout**: Fetch only current + next round from Squiggle instead of all 200+ games; add 2-min in-memory cache with stale fallback on error
- **Fix preview ordering**: Games with AI previews now appear above completed results regardless of round
- **Rename labels**: "Squiggle Prediction" → "Match Prediction", "Squiggle tips" → "Tipping"

### Eval results (25 new queries)
- **25/25 succeeded** (0 failures)
- **Avg latency: 9.3s** (down from 23.3s baseline)
- **9/25 fast-path hits** at ~1s avg

## Test plan
- [x] Run 25 new eval queries — all pass
- [x] Manual testing: pie charts, box plots, scatter plots, career stats, venue queries
- [x] Verify fast-path guards: fantasy-in-specific-round falls through to LLM
- [x] Verify off-topic fix: "How has Charlie Cameron gone this year?" no longer rejected
- [x] Live tab: previews appear above results, quarter summaries hidden
- [x] Upcoming matches load reliably with caching
- [ ] Full 128-query eval re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)